### PR TITLE
added caching mechanism to policy attributes

### DIFF
--- a/src/NCronJob/Configuration/JobOptionBuilder.cs
+++ b/src/NCronJob/Configuration/JobOptionBuilder.cs
@@ -20,7 +20,7 @@ public sealed class JobOptionBuilder
     /// </param>
     /// <param name="timeZoneInfo">Optional, provides the timezone that is used to evaluate the cron expression. Defaults to UTC.</param>
     /// <returns>Returns a <see cref="ParameterBuilder"/> that allows adding parameters to the job.</returns>
-    public ParameterBuilder WithCronExpression([StringSyntax(StringSyntaxAttribute.Regex)]string cronExpression, bool? enableSecondPrecision = null, TimeZoneInfo? timeZoneInfo = null)
+    public ParameterBuilder WithCronExpression(string cronExpression, bool? enableSecondPrecision = null, TimeZoneInfo? timeZoneInfo = null)
     {
         ArgumentNullException.ThrowIfNull(cronExpression);
 

--- a/src/NCronJob/Configuration/ServiceCollectionExtensions.cs
+++ b/src/NCronJob/Configuration/ServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ public static class ServiceCollectionExtensions
     ///     </example>
     /// </param>
     /// <returns>The modified service collection.</returns>
-    public static IServiceCollection AddNCronJob(this IServiceCollection services, Delegate jobDelegate, [StringSyntax(StringSyntaxAttribute.Regex)] string cronExpression)
+    public static IServiceCollection AddNCronJob(this IServiceCollection services, Delegate jobDelegate, string cronExpression)
         => services.AddNCronJob(builder => builder.AddJob(jobDelegate, cronExpression));
 }
 

--- a/src/NCronJob/Registry/JobAttributeCache.cs
+++ b/src/NCronJob/Registry/JobAttributeCache.cs
@@ -7,8 +7,8 @@ internal static class JobAttributeCache
     private static readonly ConcurrentDictionary<object, JobExecutionAttributes> Cache = new();
 
     public static JobExecutionAttributes GetJobExecutionAttributes(Type jobType) =>
-        Cache.GetOrAdd(jobType, (type) => JobExecutionAttributes.CreateFromType(type as Type));
+        Cache.GetOrAdd(jobType, (type) => JobExecutionAttributes.CreateFromType((Type)type));
 
     public static JobExecutionAttributes GetJobExecutionAttributes(MethodInfo methodInfo) =>
-        Cache.GetOrAdd(methodInfo, (info) => JobExecutionAttributes.CreateFromMethodInfo(info as MethodInfo));
+        Cache.GetOrAdd(methodInfo, (info) => JobExecutionAttributes.CreateFromMethodInfo((MethodInfo)info));
 }

--- a/src/NCronJob/Registry/JobAttributeCache.cs
+++ b/src/NCronJob/Registry/JobAttributeCache.cs
@@ -1,0 +1,14 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace NCronJob;
+internal static class JobAttributeCache
+{
+    private static readonly ConcurrentDictionary<object, JobExecutionAttributes> Cache = new();
+
+    public static JobExecutionAttributes GetJobExecutionAttributes(Type jobType) =>
+        Cache.GetOrAdd(jobType, (type) => JobExecutionAttributes.CreateFromType(type as Type));
+
+    public static JobExecutionAttributes GetJobExecutionAttributes(MethodInfo methodInfo) =>
+        Cache.GetOrAdd(methodInfo, (info) => JobExecutionAttributes.CreateFromMethodInfo(info as MethodInfo));
+}

--- a/src/NCronJob/Registry/JobDefinition.cs
+++ b/src/NCronJob/Registry/JobDefinition.cs
@@ -28,6 +28,7 @@ internal sealed record JobDefinition(
 
     public void IncrementJobExecutionCount() => Interlocked.Increment(ref jobExecutionCount);
 
+    private JobExecutionAttributes JobPolicyMetadata { get; } = JobPolicyMetadata ?? new JobExecutionAttributes(Type);
     public RetryPolicyAttribute? RetryPolicy => JobPolicyMetadata?.RetryPolicy;
     public SupportsConcurrencyAttribute? ConcurrencyPolicy => JobPolicyMetadata?.ConcurrencyPolicy;
 }

--- a/src/NCronJob/Registry/JobExecutionAttributes.cs
+++ b/src/NCronJob/Registry/JobExecutionAttributes.cs
@@ -1,4 +1,3 @@
-using NCronJob;
 using System.Reflection;
 
 namespace NCronJob;
@@ -67,16 +66,16 @@ internal sealed class JobExecutionAttributes
     }
 
     // Internal factory methods for cache usage
-    internal static JobExecutionAttributes CreateFromType(Type? jobType)
+    internal static JobExecutionAttributes CreateFromType(Type jobType)
     {
-        var retryPolicy = jobType?.GetCustomAttribute<RetryPolicyAttribute>();
-        var concurrencyPolicy = jobType?.GetCustomAttribute<SupportsConcurrencyAttribute>();
+        var retryPolicy = jobType.GetCustomAttribute<RetryPolicyAttribute>();
+        var concurrencyPolicy = jobType.GetCustomAttribute<SupportsConcurrencyAttribute>();
         return new JobExecutionAttributes(retryPolicy, concurrencyPolicy);
     }
 
-    internal static JobExecutionAttributes CreateFromMethodInfo(MethodInfo? methodInfo)
+    internal static JobExecutionAttributes CreateFromMethodInfo(MethodInfo methodInfo)
     {
-        var retryPolicy = methodInfo?.GetCustomAttribute<RetryPolicyAttribute>();
+        var retryPolicy = methodInfo.GetCustomAttribute<RetryPolicyAttribute>();
         var concurrencyPolicy = methodInfo?.GetCustomAttribute<SupportsConcurrencyAttribute>();
         return new JobExecutionAttributes(retryPolicy, concurrencyPolicy);
     }

--- a/src/NCronJob/Registry/JobExecutionAttributes.cs
+++ b/src/NCronJob/Registry/JobExecutionAttributes.cs
@@ -1,3 +1,4 @@
+using NCronJob;
 using System.Reflection;
 
 namespace NCronJob;
@@ -34,27 +35,49 @@ internal sealed class JobExecutionAttributes
     /// <summary>
     /// Initializes a new instance of the <see cref="JobExecutionAttributes"/> class using the specified job type or delegate.
     /// </summary>
-    /// <param name="jobType">The type of the job. Used to retrieve job-specific attributes if <paramref name="jobDelegate"/> is <c>null</c>.</param>
     /// <param name="jobDelegate">The delegate representing the job. Used to retrieve attributes directly from the delegate if not <c>null</c>.</param>
     /// <remarks>
-    /// If a <paramref name="jobDelegate"/> is provided, attributes will be retrieved from the method information of the delegate.
-    /// Otherwise, attributes will be retrieved from the <paramref name="jobType"/>.
-    /// This constructor allows for flexibility in defining job behavior either via type-level attributes or more dynamically via delegates.
+    /// Attributes will be retrieved from the method information of the delegate.
     /// </remarks>
-    public JobExecutionAttributes(Type jobType, Delegate? jobDelegate)
+    public JobExecutionAttributes(Delegate jobDelegate)
     {
-        if (jobDelegate is not null)
-        {
-            var methodInfo = jobDelegate.Method;
-            var retryPolicy = methodInfo.GetCustomAttribute<RetryPolicyAttribute>();
-            var concurrencyPolicy = methodInfo.GetCustomAttribute<SupportsConcurrencyAttribute>();
-            RetryPolicy = retryPolicy;
-            ConcurrencyPolicy = concurrencyPolicy;
-        }
-        else
-        {
-            RetryPolicy = jobType.GetCustomAttribute<RetryPolicyAttribute>();
-            ConcurrencyPolicy = jobType.GetCustomAttribute<SupportsConcurrencyAttribute>();
-        }
+        var cachedAttributes = JobAttributeCache.GetJobExecutionAttributes(jobDelegate.Method);
+        RetryPolicy = cachedAttributes.RetryPolicy;
+        ConcurrencyPolicy = cachedAttributes.ConcurrencyPolicy;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JobExecutionAttributes"/> class using the specified job type or delegate.
+    /// </summary>
+    /// <param name="jobType">The type of the job. Used to retrieve job-specific attributes.</param>
+    /// <remarks>
+    /// Attributes will be retrieved from the <paramref name="jobType"/>.
+    /// </remarks>
+    public JobExecutionAttributes(Type jobType)
+    {
+        var cachedAttributes = JobAttributeCache.GetJobExecutionAttributes(jobType);
+        RetryPolicy = cachedAttributes.RetryPolicy;
+        ConcurrencyPolicy = cachedAttributes.ConcurrencyPolicy;
+    }
+
+    private JobExecutionAttributes(RetryPolicyAttribute? retryPolicy, SupportsConcurrencyAttribute? concurrencyPolicy)
+    {
+        RetryPolicy = retryPolicy;
+        ConcurrencyPolicy = concurrencyPolicy;
+    }
+
+    // Internal factory methods for cache usage
+    internal static JobExecutionAttributes CreateFromType(Type? jobType)
+    {
+        var retryPolicy = jobType?.GetCustomAttribute<RetryPolicyAttribute>();
+        var concurrencyPolicy = jobType?.GetCustomAttribute<SupportsConcurrencyAttribute>();
+        return new JobExecutionAttributes(retryPolicy, concurrencyPolicy);
+    }
+
+    internal static JobExecutionAttributes CreateFromMethodInfo(MethodInfo? methodInfo)
+    {
+        var retryPolicy = methodInfo?.GetCustomAttribute<RetryPolicyAttribute>();
+        var concurrencyPolicy = methodInfo?.GetCustomAttribute<SupportsConcurrencyAttribute>();
+        return new JobExecutionAttributes(retryPolicy, concurrencyPolicy);
     }
 }


### PR DESCRIPTION
## Pull request description
We use reflection during Job registration to gather the metadata around the Job's attribute decorators. This PR creates a caching strategy so we only ever perform the reflection once. This also allows a `JobDefinition` to automatically set its attribute properties to reduce boilerplate code and improve maintainability. As a side-effect this allows an `InstantJobRegistry` Job to support the retry and concurrency attributes.

### PR meta checklist
- [X] Pull request is targeted at `main` branch for code   
- [X] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [X] My code follows the code style of this project and AspNetCore coding guidelines.
- [X] All tests passed.
