### PR TITLE
feat: Ability to configure global settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ## [Unreleased]
 
+### Added
+- Ability to configure the global level of concurrency for all jobs.
+```csharp
+builder.Services.AddNCronJob(
+    jobBuilder => jobBuilder.AddJob<MyJob>(),
+    globalOptions => globalOptions.MaxDegreeOfParallelism = Environment.ProcessorCount * 4);
+```
+
 ## [2.5.0] - 2024-05-21
 
 ### Changed

--- a/docs/advanced/global-concurrency.md
+++ b/docs/advanced/global-concurrency.md
@@ -14,3 +14,14 @@ A simple example: You have only one processor (therefore maximum 4 jobs executed
 So after four minutes the queue is full, and no more jobs will be added to the queue. After the fifth minute, the queue is still full, and no more jobs will be added to the queue. After the sixth minute, the first job is removed from the queue, and the next job is added to the queue. Therefore it can happen that jobs are skipped and not executed.
 
 The same applies to the `SupportsConcurrencyAttribute` discussed in: *[Concurrency Control](../features/concurrency-control.md)*
+
+## Configuration
+**NCronJob** offers the ability to change the default via an optional overload:
+
+```csharp
+builder.Services.AddNCronJob(
+    builder => builder.AddJob<MyJob>(j => j.WithCronExpression("* * * * *")),
+    options => options.MaxDegreeOfParallelism = 10);
+```
+
+This will set the maximum amount of concurrent jobs to 10. Be careful with this setting, as it can lead to performance issues if set too high. In an context of a web application, you might have less threads available that can be used to work on requests.

--- a/src/NCronJob/Configuration/JobOptionBuilder.cs
+++ b/src/NCronJob/Configuration/JobOptionBuilder.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace NCronJob;
 
 /// <summary>
@@ -43,7 +41,7 @@ public sealed class JobOptionBuilder
     internal static bool DetermineAndValidatePrecision(string cronExpression, bool? enableSecondPrecision)
     {
         var parts = cronExpression.Split(' ');
-        var precisionRequired = enableSecondPrecision ?? (parts.Length == 6);
+        var precisionRequired = enableSecondPrecision ?? parts.Length == 6;
 
         var expectedLength = precisionRequired ? 6 : 5;
         if (parts.Length != expectedLength)

--- a/src/NCronJob/GlobalOptions.cs
+++ b/src/NCronJob/GlobalOptions.cs
@@ -1,0 +1,20 @@
+namespace NCronJob;
+
+/// <summary>
+/// The global options object to configure NCronJob.
+/// </summary>
+public sealed class GlobalOptions
+{
+    /// <summary>
+    /// Gets or sets the global maximum degree of parallelism allowed for all jobs. That is, how many jobs can run in parallel.
+    /// </summary>
+    /// <remarks>
+    /// The default value is the processor count multiplied by 4.
+    /// </remarks>
+    public int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount * 4;
+
+    internal ConcurrencySettings ToConcurrencySettings() => new()
+    {
+        MaxDegreeOfParallelism = MaxDegreeOfParallelism
+    };
+}

--- a/src/NCronJob/Registry/JobDefinition.cs
+++ b/src/NCronJob/Registry/JobDefinition.cs
@@ -13,12 +13,15 @@ internal sealed record JobDefinition(
 {
     private int jobExecutionCount;
 
+    private JobExecutionAttributes JobPolicyMetadata { get; } = JobPolicyMetadata ?? new JobExecutionAttributes(Type);
+
     public CancellationToken CancellationToken { get; set; }
 
     public string JobName { get; } = JobName ?? Type.Name;
 
     /// <summary>
-    /// The JobFullName is used as a unique identifier for the job type including anonymous jobs. This helps with concurrency management.
+    /// The JobFullName is used as a unique identifier for the job type including anonymous jobs.
+    /// This helps with concurrency management.
     /// </summary>
     public string JobFullName => JobName == Type.Name
         ? Type.FullName ?? JobName
@@ -26,9 +29,9 @@ internal sealed record JobDefinition(
 
     public int JobExecutionCount => Interlocked.CompareExchange(ref jobExecutionCount, 0, 0);
 
-    public void IncrementJobExecutionCount() => Interlocked.Increment(ref jobExecutionCount);
+    public RetryPolicyAttribute? RetryPolicy => JobPolicyMetadata.RetryPolicy;
 
-    private JobExecutionAttributes JobPolicyMetadata { get; } = JobPolicyMetadata ?? new JobExecutionAttributes(Type);
-    public RetryPolicyAttribute? RetryPolicy => JobPolicyMetadata?.RetryPolicy;
-    public SupportsConcurrencyAttribute? ConcurrencyPolicy => JobPolicyMetadata?.ConcurrencyPolicy;
+    public SupportsConcurrencyAttribute? ConcurrencyPolicy => JobPolicyMetadata.ConcurrencyPolicy;
+
+    public void IncrementJobExecutionCount() => Interlocked.Increment(ref jobExecutionCount);
 }

--- a/src/NCronJob/Registry/JobExecutionAttributes.cs
+++ b/src/NCronJob/Registry/JobExecutionAttributes.cs
@@ -76,7 +76,7 @@ internal sealed class JobExecutionAttributes
     internal static JobExecutionAttributes CreateFromMethodInfo(MethodInfo methodInfo)
     {
         var retryPolicy = methodInfo.GetCustomAttribute<RetryPolicyAttribute>();
-        var concurrencyPolicy = methodInfo?.GetCustomAttribute<SupportsConcurrencyAttribute>();
+        var concurrencyPolicy = methodInfo.GetCustomAttribute<SupportsConcurrencyAttribute>();
         return new JobExecutionAttributes(retryPolicy, concurrencyPolicy);
     }
 }

--- a/src/NCronJob/RetryPolicies/ExponentialBackoffPolicyCreator.cs
+++ b/src/NCronJob/RetryPolicies/ExponentialBackoffPolicyCreator.cs
@@ -29,5 +29,4 @@ internal partial class ExponentialBackoffPolicyCreator : IPolicyCreator, IInitia
 
     [LoggerMessage(LogLevel.Warning, "Retry {RetryCount} due to error: {Message}. Retrying after {TimeSpan}.")]
     private partial void LogRetryAttempt(string message, TimeSpan timeSpan, int retryCount);
-
 }

--- a/src/NCronJob/RetryPolicies/RetryPolicyAttribute.cs
+++ b/src/NCronJob/RetryPolicies/RetryPolicyAttribute.cs
@@ -12,7 +12,6 @@ namespace NCronJob;
 /// </remarks>
 public sealed class RetryPolicyAttribute : RetryPolicyBaseAttribute
 {
-
     /// <summary>
     /// Gets the type of policy creator used to generate the retry policy.
     /// The type of policy determines how retries are performed, such as using

--- a/tests/NCronJob.Tests/NCronJobIntegrationTests.cs
+++ b/tests/NCronJob.Tests/NCronJobIntegrationTests.cs
@@ -287,8 +287,9 @@ public sealed class NCronJobIntegrationTests : JobIntegrationBase
     {
         var fakeTimer = new FakeTimeProvider();
         ServiceCollection.AddSingleton<TimeProvider>(fakeTimer);
-        ServiceCollection.AddNCronJob(n => n.AddJob<ParameterJob>(p => p.WithCronExpression("* * * * *").WithParameter("CRON")));
-        ServiceCollection.AddSingleton(_ => new ConcurrencySettings { MaxDegreeOfParallelism = 1 });
+        ServiceCollection.AddNCronJob(
+            n => n.AddJob<ParameterJob>(p => p.WithCronExpression("* * * * *").WithParameter("CRON")),
+            s => s.MaxDegreeOfParallelism = 1);
         var provider = CreateServiceProvider();
 
         await provider.GetRequiredService<IHostedService>().StartAsync(CancellationToken);


### PR DESCRIPTION
## Motivation

In an advanced scenario, a user might want to control the degree of parallel executed tasks.
For that, we offer a new `GlobalOptions` object.

## Points to consider
Design-wise the new configuration is not available on the *Minimal Job API*. The reason is that it's more likely that a user calls this more than once:
```csharp
builder.Services.AddNCronJob(() => {}, ...);
builder.Services.AddNCronJob(() => {}, ...);
```

But it is less likely that the user calls the "full" version multiple times. Nevertheless this option is global and influences the minimal job API as well.

That said, there is a drawback to the current approach. **If** the user anyway decides to call the "full" `AddNCronJob`multiple times, only the first one is put into the container and is used for the QueueWorker and Executor, **but** we evaluate the `SupportsConcurrency` attribute based on the one provided by the user. So this can lead to a mismatch and runtime issues.

Alternatively we can throw an exception if the user already registered global options.