### PR TITLE
refactor: Introduce JobRun

### DIFF
--- a/src/NCronJob/Execution/StartupJobManager.cs
+++ b/src/NCronJob/Execution/StartupJobManager.cs
@@ -3,11 +3,11 @@ internal class StartupJobManager(JobRegistry jobRegistry)
 {
     private readonly AsyncManualResetEvent startupJobsCompleted = new();
 
-    public async Task ProcessStartupJobs(Func<JobDefinition, CancellationToken, Task> executeJob, CancellationToken stopToken)
+    public async Task ProcessStartupJobs(Func<JobRun, CancellationToken, Task> executeJob, CancellationToken stopToken)
     {
         var startupJobs = jobRegistry.GetAllOneTimeJobs();
 
-        var startupTasks = startupJobs.Select(job => executeJob(job, stopToken)).ToList();
+        var startupTasks = startupJobs.Select(definition => executeJob(JobRun.Create(definition), stopToken)).ToList();
 
         if (startupTasks.Count > 0)
         {

--- a/src/NCronJob/JobExecutionContext.cs
+++ b/src/NCronJob/JobExecutionContext.cs
@@ -9,18 +9,14 @@ public sealed record JobExecutionContext
     /// <summary>
     /// Represents the context of a job execution. Marked internal to prevent external instantiation.
     /// </summary>
-    /// <param name="jobDefinition">The Job Definition of the Job Run</param>
-    internal JobExecutionContext(JobDefinition jobDefinition)
-    {
-        Parameter = jobDefinition.Parameter;
-        JobDefinition = jobDefinition;
-    }
+    /// <param name="jobRun">The Job Run.</param>
+    internal JobExecutionContext(JobRun jobRun) => JobRun = jobRun;
 
     /// <summary>
     /// Represents the context of a job execution.
     /// </summary>
     public JobExecutionContext(Type jobType, object? parameter)
-        => JobDefinition = new JobDefinition(jobType, parameter, null, null);
+        => JobRun = JobRun.Create(new JobDefinition(jobType, parameter, null, null));
 
     /// <summary>
     /// The Job Instance Identifier, generated once upon creation of the context.
@@ -39,11 +35,11 @@ public sealed record JobExecutionContext
     public int Attempts { get; internal set; }
 
     /// <summary>The Job Definition of the Job Run</summary>
-    internal JobDefinition JobDefinition { get; init; }
+    internal JobRun JobRun { get; init; }
 
     /// <summary>The Type that represents the Job</summary>
-    internal Type JobType => JobDefinition.Type;
+    internal Type JobType => JobRun.JobDefinition.Type;
 
     /// <summary>The passed in parameters to a job.</summary>
-    public object? Parameter { get; init; }
+    public object? Parameter => JobRun.Parameter;
 }

--- a/src/NCronJob/NCronJobExtensions.cs
+++ b/src/NCronJob/NCronJobExtensions.cs
@@ -35,6 +35,7 @@ public static class NCronJobExtensions
         services.TryAddSingleton(settings);
         services.AddHostedService<QueueWorker>();
         services.TryAddSingleton<JobRegistry>();
+        services.TryAddSingleton<JobHistory>();
         services.TryAddSingleton<JobQueue>();
         services.TryAddSingleton<JobExecutor>();
         services.TryAddSingleton<IRetryHandler, RetryHandler>();

--- a/src/NCronJob/Registry/IInstantJobRegistry.cs
+++ b/src/NCronJob/Registry/IInstantJobRegistry.cs
@@ -86,11 +86,7 @@ internal sealed partial class InstantJobRegistry : IInstantJobRegistry
 
         token.Register(() => LogCancellationRequested(parameter));
 
-        var run = new JobDefinition(typeof(TJob), parameter, null, null, Priority: JobPriority.High)
-        {
-            CancellationToken = token,
-            RunAt = startDate
-        };
+        var run = JobRun.Create(jobRegistry.GetJobDefinition<TJob>(), parameter, token);
 
         jobQueue.EnqueueForDirectExecution(run, startDate);
     }

--- a/src/NCronJob/Registry/JobHistory.cs
+++ b/src/NCronJob/Registry/JobHistory.cs
@@ -1,0 +1,12 @@
+using System.Collections.Concurrent;
+
+namespace NCronJob;
+
+internal sealed class JobHistory
+{
+    private readonly ConcurrentBag<JobRun> jobRuns = [];
+
+    public void Add(JobRun jobRun) => jobRuns.Add(jobRun);
+
+    public IReadOnlyCollection<JobRun> GetAll() => jobRuns;
+}

--- a/src/NCronJob/Registry/JobRegistry.cs
+++ b/src/NCronJob/Registry/JobRegistry.cs
@@ -6,12 +6,12 @@ internal sealed class JobRegistry
 {
     private readonly ImmutableArray<JobDefinition> cronJobs;
     private readonly ImmutableArray<JobDefinition> oneTimeJobs;
-    private readonly ImmutableArray<Type> allJobTypes;
+    private readonly ImmutableArray<JobDefinition> allJob;
 
     public JobRegistry(IEnumerable<JobDefinition> jobs)
     {
         var jobDefinitions = jobs as JobDefinition[] ?? jobs.ToArray();
-        allJobTypes = [..jobDefinitions.Select(j => j.Type)];
+        allJob = [..jobDefinitions];
         cronJobs = [..jobDefinitions.Where(c => c.CronExpression is not null)];
         oneTimeJobs = [..jobDefinitions.Where(c => c.IsStartupJob)];
     }
@@ -19,6 +19,8 @@ internal sealed class JobRegistry
     public IReadOnlyCollection<JobDefinition> GetAllCronJobs() => cronJobs;
     public IReadOnlyCollection<JobDefinition> GetAllOneTimeJobs() => oneTimeJobs;
 
-    public bool IsJobRegistered<T>() => allJobTypes.Any(j => j == typeof(T));
+    public bool IsJobRegistered<T>() => allJob.Any(j => j.Type == typeof(T));
+
+    public JobDefinition GetJobDefinition<T>() => allJob.First(j => j.Type == typeof(T));
 }
 

--- a/src/NCronJob/RetryPolicies/RetryHandler.cs
+++ b/src/NCronJob/RetryPolicies/RetryHandler.cs
@@ -48,11 +48,11 @@ internal sealed partial class RetryHandler : IRetryHandler
     {
         try
         {
-            var jobDefinition = runContext.JobDefinition;
+            var jobDefinition = runContext.JobRun.JobDefinition;
             var retryPolicy = jobDefinition.RetryPolicy?.CreatePolicy(serviceProvider) ?? Policy.NoOpAsync();
 
             // Execute the operation using the given retry policy
-            await retryPolicy.ExecuteAsync((ct) =>
+            await retryPolicy.ExecuteAsync(ct =>
             {
                 runContext.Attempts++;
                 if (runContext.Attempts > 1)

--- a/src/NCronJob/Scheduler/JobQueue.cs
+++ b/src/NCronJob/Scheduler/JobQueue.cs
@@ -9,7 +9,7 @@ internal sealed class JobQueue : IDisposable
 {
     private readonly TimeProvider timeProvider;
 
-    private readonly PriorityQueue<JobDefinition, (DateTimeOffset NextRunTime, int Priority)> jobQueue =
+    private readonly PriorityQueue<JobRun, (DateTimeOffset NextRunTime, int Priority)> jobQueue =
         new(new JobQueueTupleComparer());
 
     public JobQueue(TimeProvider timeProvider) => this.timeProvider = timeProvider;
@@ -21,12 +21,12 @@ internal sealed class JobQueue : IDisposable
 
     public int Count => jobQueue.Count;
 
-    public JobDefinition Dequeue() => jobQueue.Dequeue();
+    public JobRun Dequeue() => jobQueue.Dequeue();
 
-    public void Enqueue(JobDefinition job, (DateTimeOffset NextRunTime, int Priority) tuple)
+    public void Enqueue(JobRun job, (DateTimeOffset NextRunTime, int Priority) tuple)
         => jobQueue.Enqueue(job, tuple);
 
-    public bool TryPeek([NotNullWhen(true)]out JobDefinition? jobDefinition, out (DateTimeOffset NextRunTime, int Priority) tuple)
+    public bool TryPeek([NotNullWhen(true)]out JobRun? jobDefinition, out (DateTimeOffset NextRunTime, int Priority) tuple)
         => jobQueue.TryPeek(out jobDefinition, out tuple);
 
     /// <summary>
@@ -34,10 +34,10 @@ internal sealed class JobQueue : IDisposable
     /// </summary>
     /// <param name="job">The job that will be added.</param>
     /// <param name="when">An optional <see cref="DateTimeOffset"/> object representing when the job should run. If <code>null</code> it will run immediately.</param>
-    public void EnqueueForDirectExecution(JobDefinition job, DateTimeOffset? when = null)
+    public void EnqueueForDirectExecution(JobRun job, DateTimeOffset? when = null)
     {
         when ??= timeProvider.GetUtcNow();
-        jobQueue.Enqueue(job, (when.Value, (int)job.Priority));
+        jobQueue.Enqueue(job, (when.Value, (int)job.JobDefinition.Priority));
         JobEnqueued?.Invoke(this, EventArgs.Empty);
     }
 

--- a/tests/NCronJob.Tests/NCronJobIntegrationTests.cs
+++ b/tests/NCronJob.Tests/NCronJobIntegrationTests.cs
@@ -183,7 +183,8 @@ public sealed class NCronJobIntegrationTests : JobIntegrationBase
         {
             using var serviceScope = provider.CreateScope();
             using var executor = serviceScope.ServiceProvider.GetRequiredService<JobExecutor>();
-            await executor.RunJob(new JobDefinition(typeof(JobWithDependency), null, null, null), CancellationToken.None);
+            var jobDefinition = new JobDefinition(typeof(JobWithDependency), null, null, null);
+            await executor.RunJob(JobRun.Create(jobDefinition), CancellationToken.None);
         });
     }
 


### PR DESCRIPTION
I introduced a `JobRun` type that can be used further in the future.

I am not 100% sure whether or not the `JobRunRegistry` is a very good decision as it keeps memory around, which can add up over time. but maybe my concern isn't "valid".