### PR TITLE
feat: Enable Anonymous jobs for instant execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ All notable changes to **NCronJob** will be documented in this file. The project
 ### Added
 - Ability to add a timezone for a "minimal job".
 - Run jobs automatically when a job either succeeded or failed allowing to model a job pipeline. By [@linkdotnet](https://github.com/linkdotnet).
+```csharp
+builder.Services.AddNCronJob(options =>
+{
+    options.AddJob<ImportData>(p => p.WithCronExpression("0 0 * * *")
+     .ExecuteWhen(
+        success: s => s.RunJob<TransformData>("Optional Parameter"),
+        faulted: s => s.RunJob<Notify>("Another Optional Parameter"));
+});
+```
+- Minimal API for instant jobs and job dependencies. By [@linkdotnet](https://github.com/linkdotnet).
+```csharp
+public void MyOtherMethod() => jobRegistry.RunInstantJob((MyOtherService service) => service.Do());
+```
 
 ### Changed
 - Replace `Microsoft.Extensions.Hosting` with `Microsoft.Extensions.Hosting.Abstractions` for better compatibility. Reported by [@chrisls121](https://github.com/chrisls121) in [#74](https://github.com/NCronJob-Dev/NCronJob/issues/74). Implemented by [@linkdotnet](https://github.com/linkdotnet).

--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ builder.Services.AddNCronJob(options =>
 });
 ```
 
+You just want to trigger a service and don't want to define a whole new job? No problem! The Minimal API is available here as well:
+
+```csharp
+builder.Services.AddNCronJob(options =>
+{
+    options.AddJob<ImportData>(p => p.WithCronExpression("0 0 * * *")
+     .ExecuteWhen(
+        success: s => s.RunJob(async (ITransformer transformer) => await transformer.TransformDataAsync()),
+        faulted: s => s.RunJob(async (INotificationService notifier) => await notifier.NotifyAsync())
+});
+```
+
 ## Support & Contributing
 
 Thanks to all [contributors](https://github.com/NCronJob-Dev/NCronJob/graphs/contributors) and people that are creating

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ public class MyService
   public MyService(IInstantJobRegistry jobRegistry) => this.jobRegistry = jobRegistry;
 
   public void MyMethod() => jobRegistry.RunInstantJob<MyJob>("I am an optional parameter");
+    
+  // Alternatively, you can also run an anonymous job
+  public void MyOtherMethod() => jobRegistry.RunInstantJob((MyOtherService service) => service.Do());
 }
 ```
 

--- a/docs/features/instant-jobs.md
+++ b/docs/features/instant-jobs.md
@@ -83,3 +83,24 @@ app.MapPost("/send-email", (RequestDto dto, IInstantJobRegistry jobRegistry) =>
 
 ## Priority
 Instant jobs are executed with a higher priority than CRON jobs. This means that if you have a CRON job that is scheduled to run at the same time as an instant job, the instant job will be executed first (and if both of them are competing for the same resources, the instant job will be executed).
+
+## Minimal API
+Running instant jobs can also be done with the minimal API ([Minimal API](minimal-api.md)), which allows to create an anonymous lambda, that can also contain dependencies.
+
+```csharp
+app.MapPost("/send-email", (RequestDto dto, IInstantJobRegistry jobRegistry) => 
+{
+    var parameterDto = new ParameterDto
+    {
+        Email = dto.Email,
+        Subject = dto.Subject,
+        Body = dto.Body
+    };
+
+    jobRegistry.RunInstantJob(async (HttpClient httpClient) => 
+    {
+        await httpClient.PostAsync("https://api.example.com/send-email", new StringContent(JsonSerializer.Serialize(parameterDto)));
+    });
+    return TypedResults.Ok();
+});
+```

--- a/docs/features/minimal-api.md
+++ b/docs/features/minimal-api.md
@@ -88,3 +88,6 @@ The minimal API has some restrictions over the "full approach":
  * Some errors can only be detected at runtime (for example if the job does not return `void` or `Task`).
  * No support for `IJobNotificationHandler`
  * No support of defining dependencies between anonymous jobs
+
+## Minimal API for instant Jobs
+The minimal API also supports instant jobs, for this check out the [Instant Jobs](instant-jobs.md) documentation.

--- a/docs/features/minimal-api.md
+++ b/docs/features/minimal-api.md
@@ -91,3 +91,6 @@ The minimal API has some restrictions over the "full approach":
 
 ## Minimal API for instant Jobs
 The minimal API also supports instant jobs, for this check out the [Instant Jobs](instant-jobs.md) documentation.
+
+## Minimal API for dependent jobs
+The minimal API also supports dependent jobs, for this check out the [Dependent Jobs](model-dependencies.md#minimal-api) documentation.

--- a/src/NCronJob/Configuration/DynamicJobFactory.cs
+++ b/src/NCronJob/Configuration/DynamicJobFactory.cs
@@ -29,14 +29,14 @@ internal class DynamicJobFactory : IJob
             ).ToArray();
     }
 
-    private static Func<object[], Task> BuildInvoker(Delegate jobAction)
+    private static Func<object[], Task> BuildInvoker(Delegate jobDelegate)
     {
-        var method = jobAction.Method;
+        var method = jobDelegate.Method;
         var returnType = method.ReturnType;
         var param = Expression.Parameter(typeof(object[]), "args");
         var args = method.GetParameters().Select((p, index) =>
             Expression.Convert(Expression.ArrayIndex(param, Expression.Constant(index)), p.ParameterType)).ToArray();
-        var call = Expression.Call(Expression.Constant(jobAction.Target), method, args);
+        var call = Expression.Call(Expression.Constant(jobDelegate.Target), method, args);
 
         if (returnType == typeof(Task))
         {

--- a/src/NCronJob/Configuration/DynamicJobNameGenerator.cs
+++ b/src/NCronJob/Configuration/DynamicJobNameGenerator.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using System.Text;
+
+namespace NCronJob;
+
+internal static class DynamicJobNameGenerator
+{
+    /// <summary>
+    /// Construct a consistent job name from the delegate's method signature and a hash of its target
+    /// </summary>
+    /// <param name="jobDelegate">The delegate to generate a name for</param>
+    /// <returns></returns>
+    internal static string GenerateJobName(Delegate jobDelegate)
+    {
+        var methodInfo = jobDelegate.GetMethodInfo();
+        var jobNameBuilder = new StringBuilder(methodInfo.DeclaringType!.FullName);
+        jobNameBuilder.Append(methodInfo.Name);
+
+        foreach (var param in methodInfo.GetParameters())
+        {
+            jobNameBuilder.Append(param.ParameterType.Name);
+        }
+        var jobHash = jobNameBuilder.ToString().GenerateConsistentShortHash();
+        return $"AnonymousJob_{jobHash}";
+    }
+}

--- a/src/NCronJob/Configuration/DynamicJobRegistration.cs
+++ b/src/NCronJob/Configuration/DynamicJobRegistration.cs
@@ -1,0 +1,3 @@
+namespace NCronJob;
+
+internal sealed record DynamicJobRegistration(JobDefinition JobDefinition, Func<IServiceProvider, DynamicJobFactory> DynamicJobFactoryResolver);

--- a/src/NCronJob/Configuration/NCronJobOptionBuilder.cs
+++ b/src/NCronJob/Configuration/NCronJobOptionBuilder.cs
@@ -2,7 +2,6 @@ using Cronos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Reflection;
-using System.Text;
 
 namespace NCronJob;
 
@@ -202,7 +201,7 @@ internal class StartupStage<TJob> : IStartupStage<TJob> where TJob : class, IJob
     {
         if (success is not null)
         {
-            var dependencyBuilder = new DependencyBuilder<TJob>();
+            var dependencyBuilder = new DependencyBuilder<TJob>(services);
             success(dependencyBuilder);
             var runWhenSuccess = dependencyBuilder.GetDependentJobOption();
             runWhenSuccess.ForEach(s =>
@@ -215,7 +214,7 @@ internal class StartupStage<TJob> : IStartupStage<TJob> where TJob : class, IJob
 
         if (faulted is not null)
         {
-            var dependencyBuilder = new DependencyBuilder<TJob>();
+            var dependencyBuilder = new DependencyBuilder<TJob>(services);
             faulted(dependencyBuilder);
             var runWhenFaulted = dependencyBuilder.GetDependentJobOption();
             runWhenFaulted.ForEach(s =>
@@ -279,7 +278,7 @@ internal class NotificationStage<TJob> : INotificationStage<TJob> where TJob : c
     {
         if (success is not null)
         {
-            var dependencyBuilder = new DependencyBuilder<TJob>();
+            var dependencyBuilder = new DependencyBuilder<TJob>(services);
             success(dependencyBuilder);
             var runWhenSuccess = dependencyBuilder.GetDependentJobOption();
             runWhenSuccess.ForEach(s =>
@@ -292,7 +291,7 @@ internal class NotificationStage<TJob> : INotificationStage<TJob> where TJob : c
 
         if (faulted is not null)
         {
-            var dependencyBuilder = new DependencyBuilder<TJob>();
+            var dependencyBuilder = new DependencyBuilder<TJob>(services);
             faulted(dependencyBuilder);
             var runWhenFaulted = dependencyBuilder.GetDependentJobOption();
             runWhenFaulted.ForEach(s =>

--- a/src/NCronJob/NCronJobExtensions.cs
+++ b/src/NCronJob/NCronJobExtensions.cs
@@ -35,6 +35,7 @@ public static class NCronJobExtensions
         services.TryAddSingleton(settings);
         services.AddHostedService<QueueWorker>();
         services.TryAddSingleton<JobRegistry>();
+        services.TryAddSingleton<DynamicJobFactoryRegistry>();
         services.TryAddSingleton<JobHistory>();
         services.TryAddSingleton<JobQueue>();
         services.TryAddSingleton<JobExecutor>();

--- a/src/NCronJob/Registry/DynamicJobFactoryRegistry.cs
+++ b/src/NCronJob/Registry/DynamicJobFactoryRegistry.cs
@@ -1,0 +1,34 @@
+namespace NCronJob;
+
+internal sealed class DynamicJobFactoryRegistry
+{
+    private readonly JobRegistry jobRegistry;
+    private readonly Dictionary<string, Func<IServiceProvider, DynamicJobFactory>> map;
+
+    public DynamicJobFactoryRegistry(
+        IEnumerable<DynamicJobRegistration> entries,
+        JobRegistry jobRegistry)
+    {
+        this.jobRegistry = jobRegistry;
+        map = entries.ToDictionary(e => e.JobDefinition.JobFullName, v => v.DynamicJobFactoryResolver);
+    }
+
+    public JobDefinition Add(Delegate jobAction)
+    {
+        var jobPolicyMetadata = new JobExecutionAttributes(jobAction);
+        var entry = new JobDefinition(typeof(DynamicJobFactory), null, null, null,
+            JobName: DynamicJobNameGenerator.GenerateJobName(jobAction),
+            JobPolicyMetadata: jobPolicyMetadata);
+        jobRegistry.Add(entry);
+        map[entry.JobFullName] = serviceProvider => new DynamicJobFactory(serviceProvider, jobAction);
+
+        return entry;
+    }
+
+    public IJob GetAndDrainJobInstance(IServiceProvider serviceProvider, JobDefinition jobDefinition)
+    {
+        var element = map[jobDefinition.JobFullName](serviceProvider);
+        map.Remove(jobDefinition.JobFullName);
+        return element;
+    }
+}

--- a/src/NCronJob/Registry/IInstantJobRegistry.cs
+++ b/src/NCronJob/Registry/IInstantJobRegistry.cs
@@ -29,11 +29,11 @@ public interface IInstantJobRegistry
     /// Runs an instant job, which gets directly executed.
     /// </summary>
     /// <remarks>
-    /// The <paramref name="jobAction"/> delegate supports, like <see cref="ServiceCollectionExtensions.AddNCronJob"/>, that services can be retrieved dynamically.
+    /// The <paramref name="jobDelegate"/> delegate supports, like <see cref="ServiceCollectionExtensions.AddNCronJob"/>, that services can be retrieved dynamically.
     /// Also the <see cref="CancellationToken"/> can be retrieved in this way.
     /// </remarks>
-    /// <param name="jobAction">The delegate to execute.</param>
-    void RunInstantJob(Delegate jobAction);
+    /// <param name="jobDelegate">The delegate to execute.</param>
+    void RunInstantJob(Delegate jobDelegate);
 
     /// <summary>
     /// Runs a job that will be executed after the given <paramref name="delay"/>.
@@ -47,13 +47,13 @@ public interface IInstantJobRegistry
     /// <summary>
     /// Runs a job that will be executed after the given <paramref name="delay"/>.
     /// </summary>
-    /// <param name="jobAction">The delegate to execute.</param>
+    /// <param name="jobDelegate">The delegate to execute.</param>
     /// <param name="delay">The delay until the job will be executed.</param>
     /// <remarks>
-    /// The <paramref name="jobAction"/> delegate supports, like <see cref="ServiceCollectionExtensions.AddNCronJob"/>, that services can be retrieved dynamically.
+    /// The <paramref name="jobDelegate"/> delegate supports, like <see cref="ServiceCollectionExtensions.AddNCronJob"/>, that services can be retrieved dynamically.
     /// Also the <see cref="CancellationToken"/> can be retrieved in this way.
     /// </remarks>
-    void RunScheduledJob(Delegate jobAction, TimeSpan delay);
+    void RunScheduledJob(Delegate jobDelegate, TimeSpan delay);
 
     /// <summary>
     /// Runs a job that will be executed at <paramref name="startDate"/>.
@@ -67,13 +67,13 @@ public interface IInstantJobRegistry
     /// <summary>
     /// Runs a job that will be executed at the given <paramref name="startDate"/>.
     /// </summary>
-    /// <param name="jobAction">The delegate to execute.</param>
+    /// <param name="jobDelegate">The delegate to execute.</param>
     /// <param name="startDate">The starting point when the job will be executed.</param>
     /// <remarks>
-    /// The <paramref name="jobAction"/> delegate supports, like <see cref="ServiceCollectionExtensions.AddNCronJob"/>, that services can be retrieved dynamically.
+    /// The <paramref name="jobDelegate"/> delegate supports, like <see cref="ServiceCollectionExtensions.AddNCronJob"/>, that services can be retrieved dynamically.
     /// Also the <see cref="CancellationToken"/> can be retrieved in this way.
     /// </remarks>
-    void RunScheduledJob(Delegate jobAction, DateTimeOffset startDate);
+    void RunScheduledJob(Delegate jobDelegate, DateTimeOffset startDate);
 }
 
 internal sealed partial class InstantJobRegistry : IInstantJobRegistry
@@ -102,7 +102,7 @@ internal sealed partial class InstantJobRegistry : IInstantJobRegistry
     public void RunInstantJob<TJob>(object? parameter = null, CancellationToken token = default)
         where TJob : IJob => RunScheduledJob<TJob>(TimeSpan.Zero, parameter, token);
 
-    public void RunInstantJob(Delegate jobAction) => RunScheduledJob(jobAction, TimeSpan.Zero);
+    public void RunInstantJob(Delegate jobDelegate) => RunScheduledJob(jobDelegate, TimeSpan.Zero);
 
     /// <inheritdoc />
     public void RunScheduledJob<TJob>(TimeSpan delay, object? parameter = null, CancellationToken token = default)
@@ -112,10 +112,10 @@ internal sealed partial class InstantJobRegistry : IInstantJobRegistry
         RunScheduledJob<TJob>(utcNow + delay, parameter, token);
     }
 
-    public void RunScheduledJob(Delegate jobAction, TimeSpan delay)
+    public void RunScheduledJob(Delegate jobDelegate, TimeSpan delay)
     {
         var utcNow = timeProvider.GetUtcNow();
-        RunScheduledJob(jobAction, utcNow + delay);
+        RunScheduledJob(jobDelegate, utcNow + delay);
     }
 
     /// <inheritdoc />
@@ -135,9 +135,9 @@ internal sealed partial class InstantJobRegistry : IInstantJobRegistry
         jobQueue.EnqueueForDirectExecution(run, startDate);
     }
 
-    public void RunScheduledJob(Delegate jobAction, DateTimeOffset startDate)
+    public void RunScheduledJob(Delegate jobDelegate, DateTimeOffset startDate)
     {
-        var definition = dynamicJobFactoryRegistry.Add(jobAction);
+        var definition = dynamicJobFactoryRegistry.Add(jobDelegate);
         var run = JobRun.Create(definition);
         run.Priority = JobPriority.High;
 

--- a/src/NCronJob/Registry/JobRegistry.cs
+++ b/src/NCronJob/Registry/JobRegistry.cs
@@ -6,7 +6,7 @@ internal sealed class JobRegistry
 {
     private readonly ImmutableArray<JobDefinition> cronJobs;
     private readonly ImmutableArray<JobDefinition> oneTimeJobs;
-    private readonly ImmutableArray<JobDefinition> allJob;
+    private readonly List<JobDefinition> allJob;
 
     public JobRegistry(IEnumerable<JobDefinition> jobs)
     {
@@ -19,8 +19,15 @@ internal sealed class JobRegistry
     public IReadOnlyCollection<JobDefinition> GetAllCronJobs() => cronJobs;
     public IReadOnlyCollection<JobDefinition> GetAllOneTimeJobs() => oneTimeJobs;
 
-    public bool IsJobRegistered<T>() => allJob.Any(j => j.Type == typeof(T));
+    public bool IsJobRegistered<T>() => allJob.Exists(j => j.Type == typeof(T));
 
     public JobDefinition GetJobDefinition<T>() => allJob.First(j => j.Type == typeof(T));
-}
 
+    public void Add(JobDefinition jobDefinition)
+    {
+        if (!allJob.Exists(j => j.JobFullName == jobDefinition.JobFullName))
+        {
+            allJob.Add(jobDefinition);
+        }
+    }
+}


### PR DESCRIPTION
This PR allows the following:
```csharp
provider.GetRequiredService<IInstantJobRegistry>().RunInstantJob(async (ChannelWriter<object> writer) =>
{
    await writer.WriteAsync("Done");
});
```

Instant jobs that are also "just" a delegate