### PR TITLE
Update NCronJobRetryTests.cs

### DIFF
--- a/src/NCronJob/Registry/JobState.cs
+++ b/src/NCronJob/Registry/JobState.cs
@@ -17,6 +17,8 @@ internal readonly struct JobState
     }
 
     private string DebuggerDisplay => $"Type = {Type}, Timestamp = {Timestamp}";
+
+    public static implicit operator JobStateType(JobState jobState) => jobState.Type;
 }
 
 internal enum JobStateType

--- a/tests/NCronJob.Tests/TestRetryHandler.cs
+++ b/tests/NCronJob.Tests/TestRetryHandler.cs
@@ -21,6 +21,10 @@ internal sealed class TestRetryHandler(
             await retryPolicy.ExecuteAsync((ct) =>
             {
                 runContext.Attempts++;
+                if (runContext.Attempts > 1)
+                {
+                    runContext.JobRun.NotifyStateChange(JobStateType.Retrying);
+                }
                 return operation(ct);
             }, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
rewrote the unit test CancelledJobIsStillAValidExecution to leverage the job state and hooks