### PR TITLE
fix: Don't use Unsafe version for scheduler

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.26.0.92422">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.27.0.93347">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/NCronJob/Scheduler/TaskScheduler/DeterministicTaskScheduler.cs
+++ b/src/NCronJob/Scheduler/TaskScheduler/DeterministicTaskScheduler.cs
@@ -14,7 +14,7 @@ internal class DeterministicTaskScheduler : TaskScheduler
     protected override void QueueTask(Task task)
     {
         tasks.Enqueue(task);
-        ThreadPool.UnsafeQueueUserWorkItem(_ => TryExecuteTask(task), null);
+        ThreadPool.QueueUserWorkItem(_ => TryExecuteTask(task), null);
     }
 
     protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)


### PR DESCRIPTION
We probably don't wanna use the unsafe version for no good reason.