### PR TITLE
Do not treat warnings as errors while coding

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     </PropertyGroup>
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
+    <ItemGroup>
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.32.0.97167">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <PropertyGroup Label="Analyzer settings">


### PR DESCRIPTION
## Pull request description
<!--- 
    Describe the changes and motivation behind them here, if it is not obvious
    from the related issues. Does it have new features, breaking changes, etc. 
-->

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [ ] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.

:wave: This one is a very minor one. It actually aims at making the project a bit easier to onboard.

The rationale being, while working on a contribution, I'm not sure pestering the developer about XML comments and code style is the best approach. The proposal is to relax the "WarningsAsErrors" rule while coding.

As the [CI](https://github.com/NCronJob-Dev/NCronJob/blob/main/.github/workflows/dotnet.yml) is configured to build in Release mode, those warnings will eventually be fixed in order to get the pull request merged.

But it will allow one to scratch an itch, play with NCronJob code without cursing too much at the compiler while spiking something :wink: