### PR TITLE
Only publish coverage against one target framework

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,7 +36,11 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c Release /p:ContinuousIntegrationBuild=true
     - name: Test
-      run: dotnet test -c Release --no-build -p:VSTestUseMSBuildOutput=false --collect:"XPlat Code Coverage;Format=lcov" --results-directory coverage
+      run: dotnet test -c Release --no-build -p:VSTestUseMSBuildOutput=false
+
+    - name: Collect coverage
+      if: success() && matrix.os == 'ubuntu-latest'
+      run: dotnet test -c Release -f net8.0 --no-build --collect:"XPlat Code Coverage;Format=lcov" --results-directory coverage
 
     - name: Publish coverage report to coveralls.io
       if: success() && matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
## Pull request description
Coverage reports seem... a bit unstable (see https://github.com/NCronJob-Dev/NCronJob/pull/114#issuecomment-2450888724 for instance).

Currently the tests are run for both net8.0 and net9.0. As such two different coverage reports are submitted to coveralls.
Maybe this dual reporting is what generates the "instability".

This proposed change runs the tests once again, for the sole purpose of coverage analysis, but by only targeting net8.0.

### PR meta checklist
- [ ] Pull request is targeted at `main` branch for code   
- [ ] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [ ] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
