### PR TITLE
Make UseNCronJobAsync() mandatory when startup jobs have been defined

### DIFF
--- a/docs/features/startup-jobs.md
+++ b/docs/features/startup-jobs.md
@@ -33,6 +33,8 @@ app.Run();
 
 The `RunAtStartup` in combination with `UseNCronJobAsync` method ensures that the job is executed as soon as the application starts. This method is useful for scenarios where certain tasks need to be performed immediately upon application launch.
 
+Failure to call `UseNCronJobAsync` when startup jobs are defined will lead to a fatal exception during the application start.
+
 ## Example Use Case
 
 Consider an application that needs to load initial data from a database or perform some cleanup tasks whenever it starts. You can define and configure a startup job to handle this:

--- a/src/NCronJob/NCronJobExtensions.cs
+++ b/src/NCronJob/NCronJobExtensions.cs
@@ -116,12 +116,18 @@ public static class NCronJobExtensions
     /// <summary>
     /// Configures the host to use NCronJob. This will also start any given startup jobs and their dependencies.
     /// </summary>
+    /// <remarks>
+    /// Failure to call this method (or <see cref="UseNCronJobAsync(IHost)"/>) when startup jobs are defined will lead to a fatal exception during the application start.
+    /// </remarks>
     /// <param name="host">The host.</param>
     public static IHost UseNCronJob(this IHost host) => UseNCronJobAsync(host).ConfigureAwait(false).GetAwaiter().GetResult();
 
     /// <summary>
     /// Configures the host to use NCronJob. This will also start any given startup jobs and their dependencies.
     /// </summary>
+    /// <remarks>
+    /// Failure to call this method (or <see cref="UseNCronJob(IHost)"/>) when startup jobs are defined will lead to a fatal exception during the application start.
+    /// </remarks>
     /// <param name="host">The host.</param>
     public static async Task<IHost> UseNCronJobAsync(this IHost host)
     {

--- a/src/NCronJob/Scheduler/QueueWorker.LogMessage.cs
+++ b/src/NCronJob/Scheduler/QueueWorker.LogMessage.cs
@@ -39,7 +39,4 @@ internal sealed partial class QueueWorker
 
     [LoggerMessage(LogLevel.Information, "Job removed from queue: {JobType} at {RunAt}")]
     private partial void LogJobRemovedFromQueue(string jobType, DateTime? runAt);
-
-    [LoggerMessage(LogLevel.Warning, "The UseNCronJob(Async) method was not called. Startup jobs might not have been executed.")]
-    private partial void LogUseNCronJobNotCalled();
 }

--- a/src/NCronJob/Scheduler/QueueWorker.cs
+++ b/src/NCronJob/Scheduler/QueueWorker.cs
@@ -122,10 +122,20 @@ internal sealed partial class QueueWorker : BackgroundService
 
     private void AssertUseNCronJobWasCalled()
     {
-        if (!missingMethodCalledHandler.UseWasCalled)
+        if (missingMethodCalledHandler.UseWasCalled)
         {
-            LogUseNCronJobNotCalled();
+            return;
         }
+
+        if (jobRegistry.GetAllOneTimeJobs().Count == 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"""
+            Startup jobs have been registered. However, neither IHost.UseNCronJobAsync(), nor IHost.UseNCronJob() have been been called.
+            """);
     }
 
     private void CreateWorkerQueues(CancellationToken stopToken)

--- a/tests/NCronJob.Tests/RunAtStartupJobTests.cs
+++ b/tests/NCronJob.Tests/RunAtStartupJobTests.cs
@@ -8,6 +8,26 @@ namespace NCronJob.Tests;
 public class RunAtStartupJobTests : JobIntegrationBase
 {
     [Fact]
+    public async Task UseNCronJobIsMandatoryWhenStartupJobsAreDefined()
+    {
+        var builder = Host.CreateDefaultBuilder();
+        var storage = new Storage();
+        builder.ConfigureServices(services =>
+        {
+            services.AddNCronJob(s => s.AddJob<SimpleJob>().RunAtStartup());
+            services.AddSingleton(_ => storage);
+        });
+
+        using var app = builder.Build();
+
+#pragma warning disable IDISP013 // Await in using
+        Func<Task> act = () => RunApp(app);
+#pragma warning restore IDISP013 // Await in using
+
+        await act.ShouldThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
     public async Task UseNCronJobShouldTriggerStartupJobs()
     {
         var builder = Host.CreateDefaultBuilder();


### PR DESCRIPTION
## Pull request description
Follow up to https://github.com/NCronJob-Dev/NCronJob/pull/121#discussion_r1826658953

Slight enhancement to control of startup jobs.

The lib will now throw on startup only when:
- Startup jobs have been defined
- `UseNCronJobAsync` hasn't been invoked

No change at the doc level were required as no wording was hinting to `UseNCronJobAsync` being optional.

This should prevent some misconfiguration at the user level.

### PR meta checklist
- [ ] Pull request is targeted at `main` branch for code   
- [ ] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [ ] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
