### PR TITLE
Spread the new year cheer all over `IRuntimeRegistry`

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ main, v4 ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, v4 ]
+    branches: [ main ]
 
 env:
     VSTEST_CONNECTION_TIMEOUT: 180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to **NCronJob** will be documented in this file. The project
 ### Fixed
 
 - Make `RemoveJob<TJob>()` and `RemoveJob(Type)` remove all jobs of the given type. Fixed in [#151](https://github.com/NCronJob-Dev/NCronJob/issues/151), by [@nulltoken](https://github.com/nulltoken).
+- Ensure `UpdateSchedule()` behavior is consistent. Fixed in [#151](https://github.com/NCronJob-Dev/NCronJob/issues/151), by [@nulltoken](https://github.com/nulltoken).
 
 ## [v4.0.2] - 2024-12-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to **NCronJob** will be documented in this file. The project
 ### Added
 
 - Expose typed version of `DisableJob()`. Added in [#151](https://github.com/NCronJob-Dev/NCronJob/issues/151), by [@nulltoken](https://github.com/nulltoken).
+- Expose typed version of `EnableJob()`. Added in [#151](https://github.com/NCronJob-Dev/NCronJob/issues/151), by [@nulltoken](https://github.com/nulltoken).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `RemoveJob<TJob>()` and `RemoveJob(Type)` remove all jobs of the given type. Fixed in [#151](https://github.com/NCronJob-Dev/NCronJob/issues/151), by [@nulltoken](https://github.com/nulltoken).
+
 ## [v4.0.2] - 2024-12-28
 
 New `v4` release with some new features and improvements. Check the [`v4` migration guide](https://docs.ncronjob.dev/migration/v4/) for more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ## [Unreleased]
 
+### Added
+
+- Expose typed version of `DisableJob()`. Added in [#151](https://github.com/NCronJob-Dev/NCronJob/issues/151), by [@nulltoken](https://github.com/nulltoken).
+
 ### Fixed
 
 - Make `RemoveJob<TJob>()` and `RemoveJob(Type)` remove all jobs of the given type. Fixed in [#151](https://github.com/NCronJob-Dev/NCronJob/issues/151), by [@nulltoken](https://github.com/nulltoken).

--- a/docs/advanced/dynamic-job-control.md
+++ b/docs/advanced/dynamic-job-control.md
@@ -97,12 +97,26 @@ var found = registry.TryGetSchedule("MyName", out string? cronExpression, out Ti
 The cron expression and time zone can be `null` even if the job was found. This indicates that the job has no schedule (like dependent jobs).
 
 ## Disabling and enabling jobs
-To disable a job, use the `DisableJob` method:
+There are two ways to disable a job from the scheduler. By name or by type.
+
+To disable a job by name:
 
 ```csharp
 app.MapPut("/disable-job", (IRuntimeJobRegistry registry) => 
 {
     registry.DisableJob("MyName");
+    return TypedResults.Ok();
+});
+```
+
+That will prevent one job named `MyName` from being scheduled.
+
+In contrast disabling by type will disable all jobs of the given type (so zero to many jobs):
+
+```csharp
+app.MapPut("/disable-job", (IRuntimeJobRegistry registry) =>
+{
+    registry.DisableJob<SampleJob>(); // Alternatively DisableJob(typeof(SampleJob))
     return TypedResults.Ok();
 });
 ```

--- a/docs/advanced/dynamic-job-control.md
+++ b/docs/advanced/dynamic-job-control.md
@@ -123,12 +123,24 @@ app.MapPut("/disable-job", (IRuntimeJobRegistry registry) =>
 
 If a job is disabled, it will not be scheduled anymore. Any planned job will be cancelled and the job will be removed from the scheduler.
 
-To enable a job, use the `EnableJob` method:
+Of course, it's also possible to enable back previously disabled jobs.
+
+To enable a job by name:
 
 ```csharp
 app.MapPut("/enable-job", (IRuntimeJobRegistry registry) => 
 {
     registry.EnableJob("MyName");
+    return TypedResults.Ok();
+});
+```
+
+And similarly, to enable all jobs of the given type (so zero to many jobs):
+
+```csharp
+app.MapPut("/enable-job", (IRuntimeJobRegistry registry) =>
+{
+    registry.EnableJob<SampleJob>(); // Alternatively EnableJob(typeof(SampleJob))
     return TypedResults.Ok();
 });
 ```

--- a/src/NCronJob/Registry/IInstantJobRegistry.cs
+++ b/src/NCronJob/Registry/IInstantJobRegistry.cs
@@ -237,7 +237,7 @@ internal sealed partial class InstantJobRegistry : IInstantJobRegistry
     {
         using (logger.BeginScope("Triggering RunScheduledJob:"))
         {
-            var jobDefinition = jobRegistry.FindJobDefinition(typeof(TJob));
+            var jobDefinition = jobRegistry.FindFirstJobDefinition(typeof(TJob));
 
             if (jobDefinition is null)
             {

--- a/src/NCronJob/Registry/JobRegistry.cs
+++ b/src/NCronJob/Registry/JobRegistry.cs
@@ -16,7 +16,10 @@ internal sealed class JobRegistry
 
     public IReadOnlyCollection<JobDefinition> GetAllOneTimeJobs() => allJobs.Where(c => c.IsStartupJob).ToList();
 
-    public JobDefinition? FindJobDefinition(Type type)
+    public IReadOnlyCollection<JobDefinition> FindAllJobDefinition(Type type)
+        => allJobs.Where(j => j.Type == type).ToList();
+
+    public JobDefinition? FindFirstJobDefinition(Type type)
         => allJobs.FirstOrDefault(j => j.Type == type);
 
     public JobDefinition? FindJobDefinition(string jobName)
@@ -43,7 +46,15 @@ internal sealed class JobRegistry
 
     public void RemoveByName(string jobName) => Remove(allJobs.FirstOrDefault(j => j.CustomName == jobName));
 
-    public void RemoveByType(Type type) => Remove(allJobs.FirstOrDefault(j => j.Type == type));
+    public void RemoveByType(Type type)
+    {
+        var jobDefinitions = FindAllJobDefinition(type);
+
+        foreach (var jobDefinition in jobDefinitions)
+        {
+            Remove(jobDefinition);
+        }
+    }
 
     public JobDefinition AddDynamicJob(
         Delegate jobDelegate,

--- a/src/NCronJob/Registry/RuntimeJobRegistry.cs
+++ b/src/NCronJob/Registry/RuntimeJobRegistry.cs
@@ -34,11 +34,13 @@ public interface IRuntimeJobRegistry
     /// <summary>
     /// Removes all jobs of the given type.
     /// </summary>
+    /// <remarks>If the given job is not found, no exception is thrown.</remarks>
     void RemoveJob<TJob>() where TJob : IJob;
 
     /// <summary>
     /// Removes all jobs of the given type.
     /// </summary>
+    /// <remarks>If the given job is not found, no exception is thrown.</remarks>
     void RemoveJob(Type type);
 
     /// <summary>
@@ -80,7 +82,7 @@ public interface IRuntimeJobRegistry
     IReadOnlyCollection<RecurringJobSchedule> GetAllRecurringJobs();
 
     /// <summary>
-    /// This will enable a job that was previously disabled.
+    /// Enables a job that was previously disabled.
     /// </summary>
     /// <param name="jobName">The unique job name that identifies this job.</param>
     /// <remarks>
@@ -90,7 +92,7 @@ public interface IRuntimeJobRegistry
     void EnableJob(string jobName);
 
     /// <summary>
-    /// This will disable a job that was previously enabled.
+    /// Disables a job that was previously enabled.
     /// </summary>
     /// <param name="jobName">The unique job name that identifies this job.</param>
     /// <remarks>

--- a/src/NCronJob/Registry/RuntimeJobRegistry.cs
+++ b/src/NCronJob/Registry/RuntimeJobRegistry.cs
@@ -92,6 +92,24 @@ public interface IRuntimeJobRegistry
     void EnableJob(string jobName);
 
     /// <summary>
+    /// Enables all jobs of the given type that were previously disabled.
+    /// </summary>
+    /// <remarks>
+    /// If the job is already enabled, this method does nothing.
+    /// If the job is not found, an exception is thrown.
+    /// </remarks>
+    void EnableJob<TJob>() where TJob : IJob;
+
+    /// <summary>
+    /// Enables all jobs of the given type that were previously disabled.
+    /// </summary>
+    /// <remarks>
+    /// If the job is already enabled, this method does nothing.
+    /// If the job is not found, an exception is thrown.
+    /// </remarks>
+    void EnableJob(Type type);
+
+    /// <summary>
     /// Disables a job that was previously enabled.
     /// </summary>
     /// <param name="jobName">The unique job name that identifies this job.</param>
@@ -259,6 +277,15 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
                   ?? throw new InvalidOperationException($"Job with name '{jobName}' not found.");
 
         EnableJob(job, jobName);
+    }
+
+    /// <inheritdoc />
+    public void EnableJob<TJob>() where TJob : IJob => EnableJob(typeof(TJob));
+
+    /// <inheritdoc />
+    public void EnableJob(Type type)
+    {
+        ProcessAllJobDefinitionsOfType(type, j => EnableJob(j));
     }
 
     /// <inheritdoc />

--- a/src/NCronJob/Registry/RuntimeJobRegistry.cs
+++ b/src/NCronJob/Registry/RuntimeJobRegistry.cs
@@ -226,6 +226,7 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
         var cron = NCronJobOptionBuilder.GetCronExpression(cronExpression);
 
         job.CronExpression = cron;
+        job.UserDefinedCronExpression = cronExpression;
         job.TimeZone = timeZoneInfo ?? TimeZoneInfo.Utc;
 
         jobWorker.RescheduleJobWithJobName(job);

--- a/src/NCronJob/Scheduler/JobWorker.cs
+++ b/src/NCronJob/Scheduler/JobWorker.cs
@@ -223,6 +223,15 @@ internal sealed partial class JobWorker
         jobQueueManager.SignalJobQueue(jobDefinition.JobFullName);
     }
 
+    public void RescheduleJobByType(JobDefinition jobDefinition)
+    {
+        ArgumentNullException.ThrowIfNull(jobDefinition);
+
+        jobQueueManager.RemoveQueue(jobDefinition.JobFullName);
+        ScheduleJob(jobDefinition);
+        jobQueueManager.SignalJobQueue(jobDefinition.JobFullName);
+    }
+
     private void RemoveJobRunByName(string jobName)
     {
         var jobType = registry.FindJobDefinition(jobName);

--- a/src/NCronJob/Scheduler/JobWorker.cs
+++ b/src/NCronJob/Scheduler/JobWorker.cs
@@ -203,7 +203,7 @@ internal sealed partial class JobWorker
 
     public void RemoveJobType(Type type)
     {
-        var fullName = registry.FindJobDefinition(type)?.JobFullName;
+        var fullName = registry.FindFirstJobDefinition(type)?.JobFullName;
         if (fullName is null)
         {
             return;

--- a/tests/NCronJob.Tests/NCronJobIntegrationTests.cs
+++ b/tests/NCronJob.Tests/NCronJobIntegrationTests.cs
@@ -83,7 +83,7 @@ public sealed class NCronJobIntegrationTests : JobIntegrationBase
         jobFinished.ShouldBeTrue();
 
         var jobRegistry = provider.GetRequiredService<JobRegistry>();
-        jobRegistry.FindJobDefinition(typeof(SimpleJob)).ShouldBeNull();
+        jobRegistry.FindFirstJobDefinition(typeof(SimpleJob)).ShouldBeNull();
     }
 
     [Fact]

--- a/tests/NCronJob.Tests/RuntimeJobRegistryTests.cs
+++ b/tests/NCronJob.Tests/RuntimeJobRegistryTests.cs
@@ -70,6 +70,24 @@ public class RuntimeJobRegistryTests : JobIntegrationBase
     }
 
     [Fact]
+    public async Task RemovingByJobTypeAccountsForAllJobs()
+    {
+        ServiceCollection.AddNCronJob(s => s.AddJob<SimpleJob>(p => p.WithCronExpression("1 * * * *")));
+        ServiceCollection.AddNCronJob(s => s.AddJob<SimpleJob>(p => p.WithCronExpression("2 * * * *")));
+
+        var provider = CreateServiceProvider();
+        await provider.GetRequiredService<IHostedService>().StartAsync(CancellationToken);
+        var registry = provider.GetRequiredService<IRuntimeJobRegistry>();
+
+        var jobRegistry = provider.GetRequiredService<JobRegistry>();
+        Assert.Equal(2, jobRegistry.FindAllJobDefinition(typeof(SimpleJob)).Count);
+
+        registry.RemoveJob<SimpleJob>();
+
+        Assert.Empty(jobRegistry.FindAllJobDefinition(typeof(SimpleJob)));
+    }
+
+    [Fact]
     public async Task CanUpdateScheduleOfAJob()
     {
         ServiceCollection.AddNCronJob(s => s.AddJob<SimpleJob>(p => p.WithCronExpression("0 0 * * *").WithName("JobName")));

--- a/tests/NCronJob.Tests/RuntimeJobRegistryTests.cs
+++ b/tests/NCronJob.Tests/RuntimeJobRegistryTests.cs
@@ -58,6 +58,22 @@ public class RuntimeJobRegistryTests : JobIntegrationBase
     }
 
     [Fact]
+    public async Task DoesNotCringeWhenRemovingNonExistingJobs()
+    {
+        ServiceCollection.AddNCronJob();
+
+        var provider = CreateServiceProvider();
+        await provider.GetRequiredService<IHostedService>().StartAsync(CancellationToken);
+        var registry = provider.GetRequiredService<IRuntimeJobRegistry>();
+
+        var jobRegistry = provider.GetRequiredService<JobRegistry>();
+        Assert.Empty(jobRegistry.GetAllJobs());
+
+        registry.RemoveJob("Nope");
+        registry.RemoveJob<SimpleJob>();
+    }
+
+    [Fact]
     public async Task CanRemoveByJobType()
     {
         ServiceCollection.AddNCronJob(s => s.AddJob<SimpleJob>(p => p.WithCronExpression(AtEveryMinute)));


### PR DESCRIPTION
## Pull request description

### Context:
In order to not have scheduled jobs interfere with unit test runs, I leverage `IRuntimeRegistry.RemoveJob<T>` in my Xunit Collection fixtures.

As I'd rather disable them (in order to later be able to trigger them through the `IInstantJobRegistry`), I started working on making `DisableJob()` accept `IJob` typed parameters.

Getting there, it was only making sense to also consider `EnableJob()`.

Along the road, I discovered some inconsistencies nearby that I also worked on.

### Most relevant proposed changes:
- Expose typed version of `DisableJob()`
- Expose typed version of  `EnableJob()`
- Make `RemoveJob()` behave according to its documentation
- Ensure `UpdateSchedule()` behavior is consistent

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [ ] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
