### PR TITLE
Make VsCode and EditorConfig best friends again

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "[markdown]": {
+        "files.trimTrailingWhitespace": false
+    }
+}


### PR DESCRIPTION
## Pull request description
.editorconfig setting states that it's ok to have trailing whitespaces in markdown files.

This VsCode setting prevents it from short circuiting the editorconfig extension when it's installed.

Related:
- https://github.com/editorconfig/editorconfig-vscode/issues/153
- https://github.com/microsoft/vscode/issues/65663

### PR meta checklist
- [ ] Pull request is targeted at `main` branch for code   
- [ ] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [ ] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
