### PR TITLE
Allow a cron job to also run at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ### Added
 
+- Allow a cron job to also run at startup. Added in [#171](https://github.com/NCronJob-Dev/NCronJob/issues/171), by [@nulltoken](https://github.com/nulltoken).
+
 - Teach startup jobs to optionaly prevent the application start on failure. Added in [#165](https://github.com/NCronJob-Dev/NCronJob/issues/165), by [@nulltoken](https://github.com/nulltoken).
 
 ### Fixed

--- a/docs/features/startup-jobs.md
+++ b/docs/features/startup-jobs.md
@@ -35,6 +35,8 @@ The `RunAtStartup` in combination with `UseNCronJobAsync` method ensures that th
 
 Failure to call `UseNCronJobAsync` when startup jobs are defined will lead to a fatal exception during the application start.
 
+Of course, the call to `RunAtStartup` can also be chained to the registration of a standard CRON job. This setup may be useful, for instance, when one wants to prime a cache before the application starts, and then regularly refresh its content.
+
 It may happen that the specified startup job runs task that are required for the application setup. For those cases, when one cannot tolerate a startup job to fail, the `RunAtStartup` method accepts an optional parameter `shouldCrashOnFailure`. When set to `true`, the specified job is expected to complete in a successful state. Otherwise, an exception will be thrown preventing the application start.
 
 ## Example Use Case

--- a/src/NCronJob/Configuration/Builder/JobOptionBuilder.cs
+++ b/src/NCronJob/Configuration/Builder/JobOptionBuilder.cs
@@ -8,24 +8,6 @@ public sealed class JobOptionBuilder
     private readonly List<JobOption> jobOptions = [];
 
     /// <summary>
-    /// The jobOptions item we need to work with will always be the first.
-    /// This is because we only support one job per builder.
-    /// </summary>
-    /// <returns></returns>
-    internal JobOptionBuilder SetRunAtStartup(bool shouldCrashOnFailure = false)
-    {
-        if (jobOptions.Count == 1)
-        {
-            // Startup Jobs should not be initialized with a cron expression.
-            if(jobOptions[0].CronExpression != null)
-                throw new InvalidOperationException("Startup jobs cannot have a cron expression.");
-
-            jobOptions[0].ShouldCrashOnStartupFailure = shouldCrashOnFailure;
-        }
-        return this;
-    }
-
-    /// <summary>
     /// Adds a cron expression for the given job.
     /// </summary>
     /// <param name="cronExpression">The cron expression that defines when the job should be executed.</param>

--- a/tests/NCronJob.Tests/.editorconfig
+++ b/tests/NCronJob.Tests/.editorconfig
@@ -1,3 +1,7 @@
 [*.cs]
 
-dotnet_diagnostic.IDISP017.severity = none # IDISP017: Prefer using
+# IDISP017: Prefer using
+dotnet_diagnostic.IDISP017.severity = none 
+
+# CA2211: Non-constant fields should not be visible
+dotnet_diagnostic.CA2211.severity = suggestion


### PR DESCRIPTION
## Pull request description
Follow up on #170 

As NCronjob allows to register twice the same job, one instance as a cron job and another one as a startup job, the current implmentation which forbids to do so this in a single declaration makes little sense. This proposed change removes this limit.

**Before:**
```
s.AddJob<SimpleJob>().RunAtStartup();
s.AddJob<SimpleJob>(jo => jo.WithCronExpression(AtMinute5));
```

**After:**
```
s => s.AddJob<SimpleJob>(jo => jo.WithCronExpression(AtMinute5)).RunAtStartup()
```

Note:
- This change doesn't prevent the previous verbose way of registering. It only allows to do it inline as well.
- As explained in #170, it's not unusual to need a startup job to also be scheduled (Cache priming before app start, then a regular cache refresh are standard needs for instance).

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [x] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
