### PR TITLE
Cleanup job removal, [en|dis]abling and rescheduling

### DIFF
--- a/src/NCronJob/Registry/IInstantJobRegistry.cs
+++ b/src/NCronJob/Registry/IInstantJobRegistry.cs
@@ -284,7 +284,7 @@ internal sealed partial class InstantJobRegistry : IInstantJobRegistry
 
         if (forceExecution)
         {
-            _ = jobWorker.InvokeJobWithSchedule(run, token);
+            _ = jobWorker.InvokeJob(run, token);
         }
         else
         {

--- a/src/NCronJob/Registry/RuntimeJobRegistry.cs
+++ b/src/NCronJob/Registry/RuntimeJobRegistry.cs
@@ -213,7 +213,7 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
     public void RemoveJob<TJob>() where TJob : IJob => RemoveJob(typeof(TJob));
 
     /// <inheritdoc />
-    public void RemoveJob(Type type) => jobWorker.RemoveJobType(type);
+    public void RemoveJob(Type type) => jobWorker.RemoveJobByType(type);
 
     /// <inheritdoc />
     public void UpdateSchedule(string jobName, string cronExpression, TimeZoneInfo? timeZoneInfo = null)
@@ -229,7 +229,7 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
         job.UserDefinedCronExpression = cronExpression;
         job.TimeZone = timeZoneInfo ?? TimeZoneInfo.Utc;
 
-        jobWorker.RescheduleJobWithJobName(job);
+        jobWorker.RescheduleJob(job);
     }
 
     /// <inheritdoc />
@@ -240,7 +240,7 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
         var job = jobRegistry.FindJobDefinition(jobName) ?? throw new InvalidOperationException($"Job with name '{jobName}' not found.");
         job.Parameter = parameter;
 
-        jobWorker.RescheduleJobWithJobName(job);
+        jobWorker.RescheduleJob(job);
     }
 
     /// <inheritdoc />
@@ -277,7 +277,7 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
         var job = jobRegistry.FindJobDefinition(jobName)
                   ?? throw new InvalidOperationException($"Job with name '{jobName}' not found.");
 
-        EnableJob(job, jobName);
+        EnableJob(job);
     }
 
     /// <inheritdoc />
@@ -295,7 +295,7 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
         var job = jobRegistry.FindJobDefinition(jobName)
                   ?? throw new InvalidOperationException($"Job with name '{jobName}' not found.");
 
-        DisableJob(job, jobName);
+        DisableJob(job);
     }
 
     /// <inheritdoc />
@@ -317,7 +317,7 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
         }
     }
 
-    private void EnableJob(JobDefinition job, string? customName = null)
+    private void EnableJob(JobDefinition job)
     {
         if (job.UserDefinedCronExpression is not null)
         {
@@ -328,25 +328,19 @@ internal sealed class RuntimeJobRegistry : IRuntimeJobRegistry
             job.CronExpression = null;
         }
 
-        RescheduleJob(job, customName);
+        RescheduleJob(job);
     }
 
-    private void DisableJob(JobDefinition job, string? customName = null)
+    private void DisableJob(JobDefinition job)
     {
         // Scheduling on Feb, 31st is a sure way to never get it to run
         job.CronExpression = TheThirtyFirstOfFebruary;
 
-        RescheduleJob(job, customName);
+        RescheduleJob(job);
     }
 
-    private void RescheduleJob(JobDefinition job, string? customName = null)
+    private void RescheduleJob(JobDefinition job)
     {
-        if (customName is not null)
-        {
-            jobWorker.RescheduleJobWithJobName(job);
-            return;
-        }
-
-        jobWorker.RescheduleJobByType(job);
+        jobWorker.RescheduleJob(job);
     }
 }

--- a/src/NCronJob/Scheduler/JobQueue.cs
+++ b/src/NCronJob/Scheduler/JobQueue.cs
@@ -20,6 +20,4 @@ internal sealed class JobQueue : ObservablePriorityQueue<JobRun>
     {
         Enqueue(job, (job.RunAt, (int)job.Priority));
     }
-
-    public void RemoveByName(string jobName) => RemoveByPredicate(t => t.JobDefinition.CustomName == jobName);
 }

--- a/src/NCronJob/Scheduler/JobWorker.cs
+++ b/src/NCronJob/Scheduler/JobWorker.cs
@@ -66,9 +66,8 @@ internal sealed partial class JobWorker
         await Task.WhenAll(runningTasks).ConfigureAwait(false);
     }
 
-    public async Task InvokeJobWithSchedule(JobRun jobRun, CancellationToken cancellationToken)
+    public async Task InvokeJob(JobRun jobRun, CancellationToken cancellationToken)
     {
-        jobRun.NotifyStateChange(JobStateType.Scheduled);
         await WaitForNextExecution(jobRun.RunAt, cancellationToken).ConfigureAwait(false);
         await StartJobProcessingAsync(jobRun, cancellationToken).ConfigureAwait(false);
     }

--- a/src/NCronJob/Scheduler/JobWorker.cs
+++ b/src/NCronJob/Scheduler/JobWorker.cs
@@ -40,13 +40,14 @@ internal sealed partial class JobWorker
 
     public async Task WorkerAsync(string queueName, CancellationToken cancellationToken)
     {
-        var jobQueue = jobQueueManager.GetOrAddQueue(queueName);
         var concurrencyLimit = registry.GetJobTypeConcurrencyLimit(queueName);
         var semaphore = jobQueueManager.GetOrAddSemaphore(queueName, concurrencyLimit);
         var runningTasks = new List<Task>();
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            var jobQueue = jobQueueManager.GetOrAddQueue(queueName);
+
             runningTasks.RemoveAll(t => t.IsCompleted || t.IsFaulted || t.IsCanceled);
 
             if (jobQueue.TryPeek(out var nextJob, out var priorityTuple) && IsJobEligibleToStart(nextJob, jobQueue))
@@ -84,7 +85,7 @@ internal sealed partial class JobWorker
 
         try
         {
-            var cts = jobQueueManager.GetOrAddCancellationTokenSource(queueName);
+            var cts = jobQueueManager.GetCancellationTokenSource(queueName);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken);
             var linkedToken = linkedCts.Token;
 
@@ -183,6 +184,8 @@ internal sealed partial class JobWorker
 
     public void ScheduleJob(JobDefinition job)
     {
+        var jobQueue = jobQueueManager.GetOrAddQueue(job.JobFullName);
+
         if (job.CronExpression is null)
             return;
 
@@ -193,7 +196,6 @@ internal sealed partial class JobWorker
         {
             LogNextJobRun(job.Type, nextRunTime.Value);  // todo: log by subscribing to OnStateChanged => JobStateType.Scheduled
             var run = JobRun.Create(timeProvider, observer.Report, job, nextRunTime.Value);
-            var jobQueue = jobQueueManager.GetOrAddQueue(job.JobFullName);
             jobQueue.Enqueue(run, (nextRunTime.Value, (int)run.Priority));
             run.NotifyStateChange(JobStateType.Scheduled);
         }
@@ -201,54 +203,38 @@ internal sealed partial class JobWorker
 
     public void RemoveJobByName(string jobName)
     {
-        RemoveJobRunByName(jobName);
-        registry.RemoveByName(jobName);
+        RemoveJob(
+            registry.FindJobDefinition(jobName)?.JobFullName,
+            () => registry.RemoveByName(jobName));
     }
 
-    public void RemoveJobType(Type type)
+    public void RemoveJobByType(Type type)
     {
-        var fullName = registry.FindFirstJobDefinition(type)?.JobFullName;
-        if (fullName is null)
+        RemoveJob(
+            registry.FindFirstJobDefinition(type)?.JobFullName,
+            () => registry.RemoveByType(type));
+    }
+
+    private void RemoveJob(
+        string? jobDefinitionFullName,
+        Action unregistrator)
+    {
+        if (jobDefinitionFullName is null)
         {
             return;
         }
 
-        registry.RemoveByType(type);
-        jobQueueManager.RemoveQueue(fullName);
+        unregistrator();
+        jobQueueManager.RemoveQueue(jobDefinitionFullName);
+
     }
 
-    public void RescheduleJobWithJobName(JobDefinition jobDefinition)
-    {
-        ArgumentNullException.ThrowIfNull(jobDefinition);
-        ArgumentNullException.ThrowIfNull(jobDefinition.CustomName);
-
-        RemoveJobRunByName(jobDefinition.CustomName);
-        ScheduleJob(jobDefinition);
-        jobQueueManager.SignalJobQueue(jobDefinition.JobFullName);
-    }
-
-    public void RescheduleJobByType(JobDefinition jobDefinition)
+    public void RescheduleJob(JobDefinition jobDefinition)
     {
         ArgumentNullException.ThrowIfNull(jobDefinition);
 
         jobQueueManager.RemoveQueue(jobDefinition.JobFullName);
         ScheduleJob(jobDefinition);
         jobQueueManager.SignalJobQueue(jobDefinition.JobFullName);
-    }
-
-    private void RemoveJobRunByName(string jobName)
-    {
-        var jobType = registry.FindJobDefinition(jobName);
-        if (jobType is null)
-        {
-            return;
-        }
-
-        if (!jobQueueManager.TryGetQueue(jobType.JobFullName, out var jobQueue))
-        {
-            return;
-        }
-
-        jobQueue.RemoveByName(jobName);
     }
 }

--- a/src/NCronJob/Scheduler/ObservablePriorityQueue.cs
+++ b/src/NCronJob/Scheduler/ObservablePriorityQueue.cs
@@ -8,29 +8,6 @@ internal class ObservablePriorityQueue<TElement> : ObservablePriorityQueue<TElem
 {
     public ObservablePriorityQueue(IComparer<(DateTimeOffset NextRunTime, int Priority)> comparer) : base(comparer)
     { }
-
-    protected void RemoveByPredicate(Func<TElement, bool> predicate)
-    {
-        ArgumentNullException.ThrowIfNull(predicate);
-
-        lock (Lock)
-        {
-            // A unique job name can only lead to one entry in the queue
-            var elementToRemove = this.FirstOrDefault(predicate);
-            if (elementToRemove is null)
-                return;
-
-#if NET9_0_OR_GREATER
-            PriorityQueue.Remove(elementToRemove, out _, out _);
-#else
-            var allElementsExceptDeleted = PriorityQueue.UnorderedItems.Where(e => !ReferenceEquals(e.Element, elementToRemove)).ToList();
-            PriorityQueue.Clear();
-            PriorityQueue.EnqueueRange(allElementsExceptDeleted);
-#endif
-
-            InformCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, elementToRemove));
-        }
-    }
 }
 
 internal class ObservablePriorityQueue<TElement, TPriority> : IEnumerable<TElement>, INotifyCollectionChanged

--- a/tests/NCronJob.Tests/RunDependentJobTests.cs
+++ b/tests/NCronJob.Tests/RunDependentJobTests.cs
@@ -223,9 +223,9 @@ public class RunDependentJobTests : JobIntegrationBase
 
         Assert.All(events, e => Assert.Equal(orchestrationId, e.CorrelationId));
         Assert.Equal(ExecutionState.OrchestrationStarted, events[0].State);
-        Assert.Equal(ExecutionState.Completed, events[18].State);
-        Assert.Equal(ExecutionState.OrchestrationCompleted, events[19].State);
-        Assert.Equal(20, events.Count);
+        Assert.Equal(ExecutionState.Completed, events[17].State);
+        Assert.Equal(ExecutionState.OrchestrationCompleted, events[18].State);
+        Assert.Equal(19, events.Count);
     }
 
     [Fact]


### PR DESCRIPTION
## Pull request description
This started like a cleanup PR... and ended up in fixing of minor concurrency/locking related issues.

The initial trigger was an innocuous log entry that was appearing when disabling jobs

https://github.com/NCronJob-Dev/NCronJob/blob/4a8a31a5b5936f9406c5253657058aa82b49ba5c/src/NCronJob/Scheduler/JobWorker.cs#L93-L96

So I started trying to refactor this and better understand this part of the codebase.
I discovered that the RuntimeRegistry was dealing slightly differently with jobs depending if they were referred by name or by type. I thus refactored this part.

Then, I decided to enhance the current coverage of those related tests through the Observer ... and then noticed something strange: some orchestrations were blocked and never advancing. As such the tests were hanging.

I dug and fixed some cancellation tokens related topic, and other concurrency related issues which eventually made the test pass.

**Notes:**
- Despite my best attempt, I haven't been able to untangle this changeset into several commits.
- There's still some work to be done in the JobWorker/JobQueueManager area, but that's a first start

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [ ] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
