### PR TITLE
Ensure orchestration includes dependents of faulted jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,21 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure orchestration includes dependents of faulted jobs. Added in [#195](https://github.com/NCronJob-Dev/NCronJob/issues/195), by [@nulltoken](https://github.com/nulltoken).
+
 ## [v4.3.3] - 2025-01-31
 
 ### Fixed
 
-- Fixing minor concurrency issues. By [@nulltoken](https://github.com/nulltoken).
+- Fixing minor concurrency issues. By [@nulltoken](https://github.com/nulltoken) in [#184](https://github.com/NCronJob-Dev/NCronJob/issues/184).
 
 ## [v4.3.2] - 2025-01-27
 
 ### Fixed
 
-- Fixed an issue where exception handlers aren't called when a job can't be created. Reported by [@nulltoken](https://github.com/nulltoken) in #177. Fixed by [@linkdotnet](https://github.com/linkdotnet).
+- Fixed an issue where exception handlers aren't called when a job can't be created. Reported by [@nulltoken](https://github.com/nulltoken) in [#177](https://github.com/NCronJob-Dev/NCronJob/issues/177). Fixed by [@linkdotnet](https://github.com/linkdotnet) in [#179](https://github.com/NCronJob-Dev/NCronJob/issues/179).
 
 ## [v4.3.1] - 2025-01-23
 

--- a/src/NCronJob/Execution/JobExecutor.cs
+++ b/src/NCronJob/Execution/JobExecutor.cs
@@ -73,9 +73,9 @@ internal sealed partial class JobExecutor : IDisposable
         catch (Exception exc) when (exc is not OperationCanceledException or AggregateException)
         {
             LogExceptionHandlerError(runContext.JobType);
-            runContext.JobRun.NotifyStateChange(JobStateType.Faulted, exc);
             await NotifyExceptionHandlers(runContext, exc, stoppingToken);
             await AfterJobCompletionTask(runContext, exc, linkedCts.Token);
+            runContext.JobRun.NotifyStateChange(JobStateType.Faulted, exc);
         }
     }
 

--- a/tests/NCronJob.Tests/NCronJobIntegrationTests.cs
+++ b/tests/NCronJob.Tests/NCronJobIntegrationTests.cs
@@ -65,8 +65,8 @@ public sealed class NCronJobIntegrationTests : JobIntegrationBase
         FakeTimer.Advance(TimeSpan.FromMinutes(1));
 
         await Task.WhenAll(GetCompletionJobs(2, CancellationToken));
-        storage.Guids.Count.ShouldBe(2);
-        storage.Guids.Distinct().Count().ShouldBe(storage.Guids.Count);
+        storage.Entries.Count.ShouldBe(2);
+        storage.Entries.Distinct().Count().ShouldBe(storage.Entries.Count);
     }
 
     [Fact]
@@ -606,11 +606,6 @@ public sealed class NCronJobIntegrationTests : JobIntegrationBase
         public Guid NewGuid { get; } = Guid.NewGuid();
     }
 
-    private sealed class Storage
-    {
-        public ConcurrentBag<Guid> Guids { get; } = [];
-    }
-
     [SupportsConcurrency(2)]
     private sealed class SimpleJob(ChannelWriter<object> writer) : IJob
     {
@@ -657,7 +652,7 @@ public sealed class NCronJobIntegrationTests : JobIntegrationBase
     {
         public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
         {
-            storage.Guids.Add(guidGenerator.NewGuid);
+            storage.Entries.Add(guidGenerator.NewGuid.ToString());
             await writer.WriteAsync(true, token);
         }
     }

--- a/tests/NCronJob.Tests/RunAtStartupJobTests.cs
+++ b/tests/NCronJob.Tests/RunAtStartupJobTests.cs
@@ -43,8 +43,8 @@ public class RunAtStartupJobTests : JobIntegrationBase
 
         await app.UseNCronJobAsync();
 
-        storage.Content.Count.ShouldBe(1);
-        storage.Content[0].ShouldBe("SimpleJob");
+        storage.Entries.Count.ShouldBe(1);
+        storage.Entries[0].ShouldBe("SimpleJob");
     }
 
     [Theory]
@@ -111,9 +111,9 @@ public class RunAtStartupJobTests : JobIntegrationBase
         await app.UseNCronJobAsync();
         await RunApp(app);
 
-        storage.Content.Count.ShouldBe(2);
-        storage.Content[0].ShouldBe("SimpleJob");
-        storage.Content[1].ShouldBe("StartingService");
+        storage.Entries.Count.ShouldBe(2);
+        storage.Entries[0].ShouldBe("SimpleJob");
+        storage.Entries[1].ShouldBe("StartingService");
 
         Guid orchestrationId = events.First().CorrelationId;
 
@@ -154,8 +154,8 @@ public class RunAtStartupJobTests : JobIntegrationBase
         await app.UseNCronJobAsync();
         await RunApp(app);
 
-        storage.Content.Count.ShouldBe(1);
-        storage.Content[0].ShouldBe("ExceptionHandler");
+        storage.Entries.Count.ShouldBe(1);
+        storage.Entries[0].ShouldBe("ExceptionHandler");
 
         Guid orchestrationId = events.First().CorrelationId;
 
@@ -197,8 +197,8 @@ public class RunAtStartupJobTests : JobIntegrationBase
             exc.Message,
             StringComparison.Ordinal);
 
-        storage.Content.Count.ShouldBe(1);
-        storage.Content[0].ShouldBe("ExceptionHandler");
+        storage.Entries.Count.ShouldBe(1);
+        storage.Entries[0].ShouldBe("ExceptionHandler");
     }
 
     private IHost BuildApp(IHostBuilder builder)
@@ -221,24 +221,6 @@ public class RunAtStartupJobTests : JobIntegrationBase
         }
         catch (OperationCanceledException)
         {
-        }
-    }
-
-    private sealed class Storage
-    {
-#if NET9_0_OR_GREATER
-        private readonly Lock locker = new();
-#else
-        private readonly object locker = new();
-#endif
-        public List<string> Content { get; private set; } = [];
-
-        public void Add(string content)
-        {
-            lock (locker)
-            {
-                Content.Add(content);
-            }
         }
     }
 

--- a/tests/NCronJob.Tests/TestHelper.cs
+++ b/tests/NCronJob.Tests/TestHelper.cs
@@ -1,6 +1,5 @@
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -21,6 +20,7 @@ public abstract class JobIntegrationBase : IDisposable
     protected Channel<object> CommunicationChannel { get; } = Channel.CreateUnbounded<object>();
     protected ServiceCollection ServiceCollection { get; }
     protected FakeTimeProvider FakeTimer { get; } = new() { AutoAdvanceAmount = TimeSpan.FromMilliseconds(1) };
+    protected Storage Storage { get; } = new();
 
     protected JobIntegrationBase()
     {
@@ -32,6 +32,7 @@ public abstract class JobIntegrationBase : IDisposable
         ServiceCollection.AddSingleton<IRetryHandler>(sp =>
             new TestRetryHandler(sp, sp.GetRequiredService<ChannelWriter<object>>(), cancellationSignaled));
         ServiceCollection.AddSingleton<TimeProvider>(FakeTimer);
+        ServiceCollection.AddSingleton(Storage);
     }
 
     public void Dispose()
@@ -53,7 +54,10 @@ public abstract class JobIntegrationBase : IDisposable
         serviceProvider?.Dispose();
     }
 
-    protected ServiceProvider CreateServiceProvider() => serviceProvider ??= ServiceCollection.BuildServiceProvider();
+    // TODO: Replace calls to this method in the tests with `ServiceProvider`
+    protected ServiceProvider CreateServiceProvider() => ServiceProvider;
+
+    protected ServiceProvider ServiceProvider => serviceProvider ??= ServiceCollection.BuildServiceProvider();
 
     protected async Task<bool> WaitForJobsOrTimeout(int jobRuns, TimeSpan? timeOut = null)
     {
@@ -186,6 +190,26 @@ public abstract class JobIntegrationBase : IDisposable
             timeAdvancer();
             var jobResult = await CommunicationChannel.Reader.ReadAsync(cancellationToken);
             yield return jobResult;
+        }
+    }
+}
+
+public sealed class Storage
+{
+#if NET9_0_OR_GREATER
+    private readonly Lock locker = new();
+#else
+    private readonly object locker = new();
+#endif
+#pragma warning disable CA1002 // Do not expose generic lists
+    public List<string> Entries { get; private set; } = [];
+#pragma warning restore CA1002 // Do not expose generic lists
+
+    public void Add(string content)
+    {
+        lock (locker)
+        {
+            Entries.Add(content);
         }
     }
 }


### PR DESCRIPTION
## Pull request description
This started as an attempt at tackling the *"finding a way to make the tests in this repository easier to read/maintain would be a great benefit."* part from  from https://github.com/NCronJob-Dev/NCronJob/issues/147#issuecomment-2567114119

The CommunicationChannel has made me lose an insane amount of time when I started to contribute.
Thus, in order to try and improve my ~love~hate/hate relation with it, I was thinking about throwing a retiring party for it ;-)

While rewriting those tests, I stumbled on a slight concurrency issue that got also fixed as part of this PR (see inline comment in JobExecutor)

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [x] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
