### PR TITLE
Opt-in to package source mapping

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
Silence NU1507 warning (cf. https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1507)

## Pull request description
Since #166, I'm getting bullied to VisualStudio with warnings such as 

```
2>D:\__work\NCronJob\sample\RunOnceSample\RunOnceSample.csproj : warning NU1507: There are 3 package sources
defined in your configuration. When using central package management, please map your package sources 
with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single 
package source. The following sources are defined: nuget.org, [REDACTED_1], [REDACTED_2] 
```

Besides the [doco](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1507) states

```
When using NuGet's central package management (CPM), it is highly recommended that you also use 
Package Source Mapping. This can help safeguard your software supply chain is crucial if you use a mix 
of public and private package sources. Visit https://aka.ms/nuget-package-source-mapping to learn 
more about how package source mapping works.
```

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [x] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
