### PR TITLE
Instant ambiguity

### DIFF
--- a/src/NCronJob/Registry/IInstantJobRegistry.cs
+++ b/src/NCronJob/Registry/IInstantJobRegistry.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 
 namespace NCronJob;
 
@@ -250,7 +249,17 @@ internal sealed partial class InstantJobRegistry : IInstantJobRegistry
     {
         using (logger.BeginScope("Triggering RunScheduledJob:"))
         {
-            var jobDefinition = jobRegistry.FindFirstJobDefinition(typeof(TJob));
+            var jobDefinitions = jobRegistry.FindAllJobDefinition(typeof(TJob));
+
+            if (jobDefinitions.Count > 1)
+            {
+                throw new InvalidOperationException(
+                $"""
+                Ambiguous job reference for type '{typeof(TJob).Name}' detected.
+                """);
+            }
+
+            var jobDefinition = jobDefinitions.FirstOrDefault();
 
             if (jobDefinition is null)
             {

--- a/src/NCronJob/Registry/JobRegistry.cs
+++ b/src/NCronJob/Registry/JobRegistry.cs
@@ -33,7 +33,7 @@ internal sealed class JobRegistry
         {
             throw new InvalidOperationException(
                 $"""
-                Job registration conflict for type: {jobDefinition.Type.Name} detected. Another job with the same type, parameters, or cron expression already exists.
+                Job registration conflict for type '{jobDefinition.Type.Name}' detected. Another job with the same type, parameters, or cron expression already exists.
                 Please either remove the duplicate job, change its parameters, or assign a unique name to it if duplication is intended.
                 """);
         }


### PR DESCRIPTION
## Pull request description
Two different orchestrations are registered, both of them having the same typed job as root.
Which one should be picked when using the `InstantJobRegistry` to try and trigger a run by the typed job?

My proposed answer would be neither. Hence this PullRequest.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [ ] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [ ] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
