### PR TITLE
Push down some more logic into JobDefinition

### DIFF
--- a/src/NCronJob/Configuration/Builder/CronAndParameterBuilder.cs
+++ b/src/NCronJob/Configuration/Builder/CronAndParameterBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace NCronJob;
+namespace NCronJob;
 
 /// <summary>
 /// Represents a builder to refine a job with a cron expression or a parameter.
@@ -44,7 +44,7 @@ public sealed class CronAndParameterBuilder : IOptionChainerBuilder
         cronExpression = cronExpression.Trim();
 
         jobOption.CronExpression = cronExpression;
-        jobOption.TimeZoneInfo = timeZoneInfo ?? TimeZoneInfo.Utc;
+        jobOption.TimeZoneInfo = timeZoneInfo;
 
         return new ParameterOnlyBuilder(optionBuilder, jobOption);
     }

--- a/src/NCronJob/Configuration/Builder/CronAndParameterBuilder.cs
+++ b/src/NCronJob/Configuration/Builder/CronAndParameterBuilder.cs
@@ -41,8 +41,6 @@ public sealed class CronAndParameterBuilder : IOptionChainerBuilder
     {
         ArgumentNullException.ThrowIfNull(cronExpression);
 
-        cronExpression = cronExpression.Trim();
-
         jobOption.CronExpression = cronExpression;
         jobOption.TimeZoneInfo = timeZoneInfo;
 

--- a/src/NCronJob/Configuration/Builder/JobOption.cs
+++ b/src/NCronJob/Configuration/Builder/JobOption.cs
@@ -3,7 +3,7 @@ namespace NCronJob;
 /// <summary>
 /// A configuration option for a job.
 /// </summary>
-internal sealed class JobOption
+internal class JobOption
 {
     /// <summary>
     /// Set's the cron expression for the job. If set to null, the job is added to the container but will not be scheduled.
@@ -17,7 +17,7 @@ internal sealed class JobOption
     /// <summary>
     /// The timezone that is used to evaluate the cron expression. Defaults to UTC.
     /// </summary>
-    public TimeZoneInfo TimeZoneInfo { get; set; } = TimeZoneInfo.Utc;
+    public TimeZoneInfo? TimeZoneInfo { get; set; }
 
     /// <summary>
     /// The parameter that can be passed down to the job. This only applies to cron jobs.<br/>

--- a/src/NCronJob/Configuration/Builder/JobOptionBuilder.cs
+++ b/src/NCronJob/Configuration/Builder/JobOptionBuilder.cs
@@ -17,8 +17,6 @@ public sealed class JobOptionBuilder
     {
         ArgumentNullException.ThrowIfNull(cronExpression);
 
-        cronExpression = cronExpression.Trim();
-
         var jobOption = new JobOption
         {
             CronExpression = cronExpression,

--- a/src/NCronJob/Configuration/Builder/JobOptionBuilder.cs
+++ b/src/NCronJob/Configuration/Builder/JobOptionBuilder.cs
@@ -22,7 +22,7 @@ public sealed class JobOptionBuilder
         var jobOption = new JobOption
         {
             CronExpression = cronExpression,
-            TimeZoneInfo = timeZoneInfo ?? TimeZoneInfo.Utc
+            TimeZoneInfo = timeZoneInfo
         };
 
         jobOptions.Add(jobOption);

--- a/src/NCronJob/Registry/JobDefinition.cs
+++ b/src/NCronJob/Registry/JobDefinition.cs
@@ -49,7 +49,7 @@ internal sealed record JobDefinition
     /// This is the unhandled cron expression from the user. Using <see cref="CronExpression.ToString"/> will alter the expression.
     /// For example:
     /// <code>
-    /// var cron = CronExpression.Parse("0  0 1 * *"); // Extra whitespace
+    /// var cron = CronExpression.Parse("  0 0 1 * *"); // Extra whitespace
     /// cron.ToString(); // No extra whitespace: 0 0 1 * *
     /// var cron = CronExpression.Parse("*/2 * * *");
     /// cron.ToString(); // 0,2,4,6,8,10,12,... * * * *
@@ -148,7 +148,7 @@ internal sealed record JobDefinition
         if (jobOption.CronExpression is not null)
         {
             UserDefinedCronExpression = jobOption.CronExpression;
-            CronExpression = GetCronExpression(jobOption.CronExpression);
+            CronExpression = GetCronExpression(jobOption.CronExpression.Trim());
 
             TimeZone = jobOption.TimeZoneInfo;
         }

--- a/src/NCronJob/Registry/JobRegistry.cs
+++ b/src/NCronJob/Registry/JobRegistry.cs
@@ -64,20 +64,8 @@ internal sealed class JobRegistry
     {
         var jobPolicyMetadata = new JobExecutionAttributes(jobDelegate);
 
-        var entry = JobDefinition.CreateUntyped(DynamicJobNameGenerator.GenerateJobName(jobDelegate), jobPolicyMetadata) with
-        {
-            CustomName = jobName
-        };
-
-        if (jobOption is not null)
-        {
-            Debug.Assert(jobOption.CronExpression is not null);
-
-            var cron = NCronJobOptionBuilder.GetCronExpression(jobOption.CronExpression);
-            entry.CronExpression = cron;
-            entry.TimeZone = jobOption.TimeZoneInfo;
-            entry.UserDefinedCronExpression = jobOption.CronExpression;
-        }
+        var entry = JobDefinition.CreateUntyped(jobName, DynamicJobNameGenerator.GenerateJobName(jobDelegate), jobPolicyMetadata);
+        entry.UpdateWith(jobOption);
 
         Add(entry);
         AddDynamicJobRegistration(entry, jobDelegate);
@@ -119,7 +107,7 @@ internal sealed class JobRegistry
     {
         foreach (var jobDefinition in jobDefinitions)
         {
-            jobDefinition.ShouldCrashOnStartupFailure = shouldCrashOnFailure;
+            jobDefinition.UpdateWith(new JobOption() { ShouldCrashOnStartupFailure = shouldCrashOnFailure });
         }
     }
 

--- a/src/NCronJob/Scheduler/JobWorker.cs
+++ b/src/NCronJob/Scheduler/JobWorker.cs
@@ -192,7 +192,7 @@ internal sealed partial class JobWorker
     public void ScheduleJob(JobDefinition job)
     {
         var utcNow = timeProvider.GetUtcNow();
-        var nextRunTime = job.GetNextCronOccurrence(utcNow, job.TimeZone);
+        var nextRunTime = job.GetNextCronOccurrence(utcNow);
 
         if (!nextRunTime.HasValue)
         {

--- a/tests/NCronJob.Tests/JobRunTests.cs
+++ b/tests/NCronJob.Tests/JobRunTests.cs
@@ -26,8 +26,8 @@ public class JobRunStatesTests
     [Fact]
     public void TestValuesAreInSyncWithCurrentEnumValues()
     {
-        List<JobStateType> expected = Enum.GetValues<JobStateType>().ToList();
-        List<JobStateType> actual = AllPossibleStates.Keys.ToList();
+        var expected = Enum.GetValues<JobStateType>().ToList();
+        var actual = AllPossibleStates.Keys.ToList();
         actual.ShouldBeEquivalentTo(expected);
     }
 
@@ -35,9 +35,9 @@ public class JobRunStatesTests
     [ClassData(typeof(FinalJobStateTypeTestData))]
     internal void CompletedJobRunsCannotChangeTheirStateFurther(JobStateType value)
     {
-        int howManyTimes = 0;
+        var howManyTimes = 0;
 
-        JobDefinition jd = JobDefinition.CreateTyped(typeof(DummyJob), null);
+        var jd = JobDefinition.CreateTyped(typeof(DummyJob), null);
         var jobRun = JobRun.Create(new FakeTimeProvider(), (jr) => { howManyTimes++; }, jd);
 
         jobRun.CurrentState.Type.ShouldBe(JobStateType.NotStarted);
@@ -49,7 +49,7 @@ public class JobRunStatesTests
         jobRun.CurrentState.Type.ShouldBe(value);
         howManyTimes.ShouldBe(2);
 
-        foreach (JobStateType state in AllPossibleStates.Keys)
+        foreach (var state in AllPossibleStates.Keys)
         {
             jobRun.NotifyStateChange(state, fault);
             jobRun.CurrentState.Type.ShouldBe(value);
@@ -61,9 +61,9 @@ public class JobRunStatesTests
     [ClassData(typeof(AllJobStateTypeTestData))]
     internal void OnlyRetryingJobRunsCanTriggerMoreThanOnceTheProgressReporter(JobStateType value)
     {
-        int howManyTimes = 0;
+        var howManyTimes = 0;
 
-        JobDefinition jd = JobDefinition.CreateTyped(typeof(DummyJob), null);
+        var jd = JobDefinition.CreateTyped(typeof(DummyJob), null);
         var jobRun = JobRun.Create(new FakeTimeProvider(), (jr) => { howManyTimes++; }, jd);
 
         jobRun.CurrentState.Type.ShouldBe(JobStateType.NotStarted);

--- a/tests/NCronJob.Tests/TimeZoneTests.cs
+++ b/tests/NCronJob.Tests/TimeZoneTests.cs
@@ -20,14 +20,14 @@ public sealed class TimeZoneTests : JobIntegrationBase
     }
 
     [Fact]
-    public void ShouldDefaultToUtcIfTimeZoneNotSpecified()
+    public void ShouldNotInferAnythingIfTimeZoneNotSpecified()
     {
         var builder = new JobOptionBuilder();
         builder.WithCronExpression(Cron.AtEveryMinute);
 
         var options = builder.GetJobOptions();
 
-        options.Single().TimeZoneInfo.ShouldBe(TimeZoneInfo.Utc);
+        options.Single().TimeZoneInfo.ShouldBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Pull request description
While working on #247, I discovered some refactoring opportunities isolated into this PR.

This moves down into `JobDefinition` more logic.
- Its name cannot be changed, because it's the sole identifier that allows to interact with it through the `RuntimeRegistry`. As such, it's now initialized through the constructor, and cannot be altered once set.
- The properties are no longer settable. `UpdateWith()` is the only way to alter it. This allows more control with regards to how a `JobDefinition` can mutate.

This change is also a step in the direction of #218.

Fix #243 

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [x] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [ ] I have added, updated or removed tests to according to my changes.
  - [ ] All tests passed.
