### PR TITLE
Straighten registration of untyped named jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to **NCronJob** will be documented in this file. The project
 
 ## [Unreleased]
 
+- Allow the registration of the same untyped job with different names. Reported by [@Mangatome](https://github.com/Mangatome) in [#~253](https://github.com/NCronJob-Dev/NCronJob/issues/253). Fixed by [@nulltoken](https://github.com/nulltoken) in [#252](https://github.com/NCronJob-Dev/NCronJob/pull/252) and [#254](https://github.com/NCronJob-Dev/NCronJob/pull/254).
+
 ## [v4.4.0] - 2025-03-10
 
 ### Added

--- a/src/NCronJob/Registry/JobDefinition.cs
+++ b/src/NCronJob/Registry/JobDefinition.cs
@@ -28,7 +28,9 @@ internal sealed record JobDefinition
 
         Delegate = jobDelegate;
         IsTypedJob = false;
-        JobFullName = $"Untyped job {typeof(DynamicJobFactory).Namespace}.{DynamicJobNameGenerator.GenerateJobName(jobDelegate)}";
+        JobFullName = customName is not null ?
+            $"Untyped job {customName}" :
+            $"Untyped job {typeof(DynamicJobFactory).Namespace}.{DynamicJobNameGenerator.GenerateJobName(jobDelegate)}";
 
         JobPolicyMetadata = new JobExecutionAttributes(jobDelegate);
     }

--- a/src/NCronJob/Registry/JobRegistry.cs
+++ b/src/NCronJob/Registry/JobRegistry.cs
@@ -145,7 +145,7 @@ internal sealed class JobRegistry
 
         public bool Equals(JobDefinition? x, JobDefinition? y) =>
             (x is null && y is null) || (x is not null && y is not null
-                                         && x.Type == y.Type && x.IsTypedJob
+                                         && x.JobFullName == y.JobFullName
                                          && x.Parameter == y.Parameter
                                          && x.CronExpression == y.CronExpression
                                          && x.TimeZone == y.TimeZone
@@ -153,7 +153,7 @@ internal sealed class JobRegistry
                                          && x.IsStartupJob == y.IsStartupJob);
 
         public int GetHashCode(JobDefinition obj) => HashCode.Combine(
-            obj.Type,
+            obj.JobFullName,
             obj.Parameter,
             obj.CronExpression,
             obj.TimeZone,


### PR DESCRIPTION
#252 makes #253 no longer an issue.
However, #253 puts under the light some room for improvement. This PR attempts at fixing this.

## Pull request description
- When provided, use custom untyped job names to value FullJobName (Should make generated logging more actionable)
- Enlist FullJobName in JobDefinition equality comparer (which should cover for both untyped and typed jobs)

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [x] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
