### PR TITLE
Protect dependent jobs from removal

### DIFF
--- a/src/NCronJob/Configuration/Builder/DependencyBuilder.cs
+++ b/src/NCronJob/Configuration/Builder/DependencyBuilder.cs
@@ -33,8 +33,8 @@ public sealed class DependencyBuilder<TPrincipalJob>
     {
         ArgumentNullException.ThrowIfNull(jobDelegate);
 
-        var entry = jobRegistry.AddDynamicJob(jobDelegate, jobName);
-        dependentJobOptions.Add(entry);
+        var jobDefinition = JobDefinition.CreateUntyped(jobName, jobDelegate);
+        dependentJobOptions.Add(jobDefinition);
 
         return this;
     }

--- a/src/NCronJob/Configuration/Builder/NCronJobOptionBuilder.cs
+++ b/src/NCronJob/Configuration/Builder/NCronJobOptionBuilder.cs
@@ -91,7 +91,10 @@ public class NCronJobOptionBuilder : IJobStage, IRuntimeJobBuilder
             TimeZoneInfo = timeZoneInfo
         };
 
-        jobRegistry.AddDynamicJob(jobDelegate, jobName, jobOption);
+        var jobDefinition = JobDefinition.CreateUntyped(jobName, jobDelegate);
+        jobDefinition.UpdateWith(jobOption);
+
+        jobRegistry.Add(jobDefinition);
 
         return this;
     }

--- a/src/NCronJob/Registry/IInstantJobRegistry.cs
+++ b/src/NCronJob/Registry/IInstantJobRegistry.cs
@@ -324,9 +324,9 @@ internal sealed partial class InstantJobRegistry : IInstantJobRegistry
 
     private Guid RunDelegateJob(Delegate jobDelegate, DateTimeOffset startDate, bool forceExecution = false, CancellationToken token = default)
     {
-        var definition = jobRegistry.AddDynamicJob(jobDelegate);
+        var jobDefinition = JobDefinition.CreateUntyped(null, jobDelegate);
 
-        return RunInternal(definition, null, startDate, forceExecution, token);
+        return RunInternal(jobDefinition, null, startDate, forceExecution, token);
     }
 
     private Guid RunJob<TJob>(DateTimeOffset startDate, object? parameter = null, bool forceExecution = false, CancellationToken token = default)

--- a/src/NCronJob/Scheduler/JobWorker.cs
+++ b/src/NCronJob/Scheduler/JobWorker.cs
@@ -209,28 +209,24 @@ internal sealed partial class JobWorker
 
     public void RemoveJobByName(string jobName)
     {
-        RemoveJob(
-            registry.FindJobDefinition(jobName)?.JobFullName,
-            () => registry.RemoveByName(jobName));
+        RemoveJob(() => registry.RemoveByName(jobName));
     }
 
     public void RemoveJobByType(Type type)
     {
-        RemoveJob(
-            registry.FindFirstJobDefinition(type)?.JobFullName,
-            () => registry.RemoveByType(type));
+        RemoveJob(() => registry.RemoveByType(type));
     }
 
     private void RemoveJob(
-        string? jobDefinitionFullName,
-        Action unregistrator)
+        Func<string?> unregistrator)
     {
+        var jobDefinitionFullName = unregistrator();
+
         if (jobDefinitionFullName is null)
         {
             return;
         }
 
-        unregistrator();
         jobQueueManager.RemoveQueue(jobDefinitionFullName);
 
     }


### PR DESCRIPTION
## Pull request description

Another corner case discovered while working on #255: We can't blindly remove a `JobDefinition` when it's used for a dependent job.

Also fix the intent of a test that doesn't seem to be properly expressed. A dependent job cannot have a schedule. As such, it shouldn't be retrievable through `IRuntimeRegistry.TryGetSchedule()`.

### PR meta checklist
- [x] Pull request is targeted at `main` branch for code   
- [x] Pull request is linked to all related issues, if any.

### Code PR specific checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
